### PR TITLE
Potential fix for code scanning alert no. 10: Incomplete URL substring sanitization

### DIFF
--- a/src/services/git-platform-service.ts
+++ b/src/services/git-platform-service.ts
@@ -337,7 +337,14 @@ export class GitPlatformServiceFactory {
       }
 
       // Test GitHub API endpoint
-      const githubApiUrl = baseUrl.includes('github.com') ? 'https://api.github.com' : `${baseUrl}/api/v3`;
+      // Use URL parsing to avoid unsafe substring check (see CodeQL warning)
+      let hostname;
+      try {
+        hostname = new URL(baseUrl).hostname;
+      } catch {
+        hostname = '';
+      }
+      const githubApiUrl = hostname === 'github.com' ? 'https://api.github.com' : `${baseUrl}/api/v3`;
       GitPlatformServiceFactory.logger.debug(`Testing GitHub API: ${githubApiUrl}`);
       
       const controller2 = new AbortController();


### PR DESCRIPTION
Potential fix for [https://github.com/HeiSir2014/git-aiflow/security/code-scanning/10](https://github.com/HeiSir2014/git-aiflow/security/code-scanning/10)

To fix the problem, we should avoid using `baseUrl.includes('github.com')`. Instead, parse `baseUrl` using the standard URL parser (the `URL` class in JavaScript/TypeScript), extract the `hostname`, and check if it is exactly `'github.com'` or one of a set of explicit allowed hostnames. In this code, the intention appears to be to use the GitHub API endpoint if the URL **host** is `github.com`. Thus, replace the substring check with an explicit hostname check, e.g., `new URL(baseUrl).hostname === 'github.com'`. 

Edit the relevant code in `src/services/git-platform-service.ts`, specifically line 340. Add an import of the standard `url` library only if necessary (with modern Node.js and TypeScript, the global `URL` is sufficient, so no new import is strictly needed unless the codebase prefers explicit imports). No other functionality or logic should be changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
