### PR TITLE
Potential fix for code scanning alert no. 7: Regular expression injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
     "clipboardy": "^4.0.0",
     "dotenv": "^17.2.2",
     "js-yaml": "^4.1.0",
-    "winston": "^3.17.0"
+    "winston": "^3.17.0",
+    "lodash": "^4.17.21"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/src/services/conanlock-service.ts
+++ b/src/services/conanlock-service.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { escapeRegExp } from 'lodash';
 
 /**
  * Interface for Conan lock file entry
@@ -78,8 +79,9 @@ export class ConanLockService {
     
     // Pattern to match package lock entries
     // Matches: "packageName/version#hash%timestamp"
+    const safePackageName = escapeRegExp(packageName);
     const lockPattern = new RegExp(
-      `"${packageName}\/[^#]+#[^%]+%[^"]+"`,'g'
+      `"${safePackageName}\/[^#]+#[^%]+%[^"]+"`,'g'
     );
     
     let updatedContent = content;
@@ -137,9 +139,10 @@ export class ConanLockService {
   getCurrentLockInfo(packageName: string): ConanLockEntry | null {
     const content = this.readContent();
     
+    const safePackageName = escapeRegExp(packageName);
     // Pattern to find package lock entry
     const lockPattern = new RegExp(
-      `"(${packageName}\/[^#]+#[^%]+%[^"]+)"`, 'g'
+      `"(${safePackageName}\/[^#]+#[^%]+%[^"]+)"`, 'g'
     );
     
     const match = lockPattern.exec(content);


### PR DESCRIPTION
Potential fix for [https://github.com/HeiSir2014/git-aiflow/security/code-scanning/7](https://github.com/HeiSir2014/git-aiflow/security/code-scanning/7)

To fix the regular expression injection, user-provided values interpolated into a regular expression must be sanitized such that any characters with special meaning in regex patterns are escaped.  
The best approach is to use a robust, well-tested method such as `_.escapeRegExp` from the `lodash` library for JavaScript/TypeScript projects. This method escapes all characters with special meaning in regexes, turning them into literal matches.

**Implementation steps:**
- Import `escapeRegExp` (from `lodash`) at the top of `src/services/conanlock-service.ts`.
- In both locations in `ConanLockService` where a RegExp is constructed using `${packageName}`, first sanitize it:  
  - Define `const safePackageName = escapeRegExp(packageName);`
  - Use `safePackageName` instead of the raw `packageName` in the regex string.
- Make sure this change is applied consistently to both `updatePackageVersion` (line 82) and `getCurrentLockInfo` (line 142).
- No change to logic/behavior, just secure how the regex is constructed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
