### PR TITLE
feat: 添加AI生成内容的语言配置支持

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -49,6 +49,10 @@ git:
   
   # 删除源分支 (可选) - 合并后是否删除源分支，默认为true
   removeSourceBranch: true
+  
+  # AI生成语言 (可选) - AI生成commit message和MR描述的语言，默认为en
+  # 支持的语言代码: en, zh-CN, zh-TW, ja, ko, fr, de, es, ru, pt, it
+  generation_lang: en
 
 # 合并请求指派配置 - 配置指派人和审查者
 merge_request:

--- a/src/aiflow-app.ts
+++ b/src/aiflow-app.ts
@@ -353,10 +353,11 @@ export abstract class BaseAiflowApp {
 
       // Step 3: Generate commit message and branch name using AI
       console.log(`🤖 Generating commit message and branch name...`);
-      const { commit, branch } = await this.openai.generateCommitAndBranch(diff);
+      const { commit, branch, description } = await this.openai.generateCommitAndBranch(diff, getConfigValue(this.config, 'git.generation_lang', 'en'));
 
       console.log("✅ Generated commit message:", commit);
       console.log("✅ Generated branch suggestion:", branch);
+      console.log("✅ Generated MR description:", description);
 
       // Step 4: Create branch name
       const gitUser = this.git.getUserName();
@@ -381,7 +382,8 @@ export abstract class BaseAiflowApp {
 
       const mergeRequestOptions: MergeRequestOptions = {
         squash: squashCommits,
-        removeSourceBranch: removeSourceBranch
+        removeSourceBranch: removeSourceBranch,
+        description: description
       };
 
       // Add assignee configuration if specified

--- a/src/aiflow-conan-app.ts
+++ b/src/aiflow-conan-app.ts
@@ -71,7 +71,8 @@ export class ConanPkgUpdateApp extends BaseAiflowApp {
 
       // Step 4: Generate commit message and branch name using AI
       console.log(`🤖 Generating commit message and branch name...`);
-      const { commit, branch } = await this.openai.generateCommitAndBranch(diff);
+      const { commit, branch, description } = await this.openai.generateCommitAndBranch(diff, getConfigValue(this.config, 'git.generation_lang', 'en'));
+      console.log("✅ Generated MR description:", description);
 
       // Step 5: Create new branch
       const gitUser = this.git.getUserName();
@@ -104,7 +105,8 @@ export class ConanPkgUpdateApp extends BaseAiflowApp {
 
       const mergeRequestOptions: MergeRequestOptions = {
         squash: squashCommits,
-        removeSourceBranch: removeSourceBranch
+        removeSourceBranch: removeSourceBranch,
+        description: description
       };
 
       // Add assignee configuration if specified

--- a/src/config.ts
+++ b/src/config.ts
@@ -94,6 +94,7 @@ export interface AiflowConfig {
   git?: {
     squashCommits?: boolean;
     removeSourceBranch?: boolean;
+    generation_lang?: string;
   };
 
   // Merge Request Configuration
@@ -187,6 +188,7 @@ export class ConfigLoader {
       'WECOM_ENABLE': 'wecom.enable',
       'SQUASH_COMMITS': 'git.squashCommits',
       'REMOVE_SOURCE_BRANCH': 'git.removeSourceBranch',
+      'GIT_GENERATION_LANG': 'git.generation_lang',
       'MERGE_REQUEST_ASSIGNEE_ID': 'merge_request.assignee_id',
       'MERGE_REQUEST_ASSIGNEE_IDS': 'merge_request.assignee_ids',
       'MERGE_REQUEST_REVIEWER_IDS': 'merge_request.reviewer_ids',
@@ -206,7 +208,7 @@ export class ConfigLoader {
       const envValue = process.env[envKey];
       if (envValue !== undefined) {
         let parsedValue = this.parseEnvValue(envValue);
-        
+
         // Handle array fields for merge request configuration
         if (configPath === 'merge_request.assignee_ids' || configPath === 'merge_request.reviewer_ids') {
           if (typeof parsedValue === 'string') {
@@ -222,7 +224,7 @@ export class ConfigLoader {
             parsedValue = isNaN(num) ? 0 : num;
           }
         }
-        
+
         this.setNestedValue(config, configPath, parsedValue);
         config._sources.set(configPath, { source: 'env' });
       }
@@ -666,6 +668,10 @@ export function parseCliArgs(args: string[]): Partial<AiflowConfig> {
         config.git = { ...config.git, removeSourceBranch: value !== 'false' };
         i++;
         break;
+      case 'git-generation-lang':
+        config.git = { ...config.git, generation_lang: value };
+        i++;
+        break;
       case 'merge-request-assignee-id':
         const assigneeId = parseInt(value, 10);
         config.merge_request = { ...config.merge_request, assignee_id: isNaN(assigneeId) ? 0 : assigneeId };
@@ -720,9 +726,10 @@ function getShortArgMapping(shortKey: string): string {
     'ww': 'wecom-webhook',
     'we': 'wecom-enable',
 
-    // Git shortcuts (Squash Commits, Remove Source Branch)
+    // Git shortcuts (Squash Commits, Remove Source Branch, Generate Language)
     'sc': 'squash-commits',
     'rsb': 'remove-source-branch',
+    'ggl': 'git-generation-lang',
 
     // Merge Request shortcuts (Merge Request Assignee ID, Assignee IDs, Reviewer IDs)
     'mrai': 'merge-request-assignee-id',
@@ -769,6 +776,7 @@ Conan 配置 - C++包管理:
 Git 配置 - 合并请求行为:
   -sc, --squash-commits <bool>          压缩提交 (可选，合并时压缩多个提交)
   -rsb, --remove-source-branch <bool>   删除源分支 (可选，合并后删除分支)
+  -ggl, --git-generation-lang <lang>      生成语言 (可选，AI生成内容的语言，如: zh-CN, en, ja)
 
 合并请求配置 - 指派和审查者:
   -mrai, --merge-request-assignee-id <id>      单个指派人用户ID (可选，设置为0取消指派)
@@ -824,6 +832,26 @@ export async function initConfig(isGlobal: boolean = false): Promise<void> {
   console.log(`📁 配置位置: ${configPath}`);
   console.log('💡 提示：直接回车使用默认值或跳过可选配置\n');
 
+  // Check if this is incremental configuration
+  const hasExistingConfig = fs.existsSync(configPath);
+  let hasGlobalConfig = false;
+  let globalConfigPath = '';
+
+  if (!isGlobal) {
+    // For local config, check if global config exists
+    const userDataDir = getUserDataDir();
+    globalConfigPath = path.join(userDataDir, 'aiflow', 'config.yaml');
+    hasGlobalConfig = fs.existsSync(globalConfigPath);
+
+    if (hasGlobalConfig) {
+      console.log('📋 检测到全局配置，您可以选择增量配置模式');
+      console.log('💡 增量配置模式：基于全局配置，只配置您想要在本地覆盖的模块\n');
+    }
+  } else if (hasExistingConfig) {
+    console.log('📋 检测到现有全局配置，您可以选择增量配置模式');
+    console.log('💡 增量配置模式：只配置您想要修改的模块，其他保持不变\n');
+  }
+
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout
@@ -836,6 +864,54 @@ export async function initConfig(isGlobal: boolean = false): Promise<void> {
   };
 
   try {
+    // Incremental configuration mode selection
+    let configModules: string[] = [];
+    const canUseIncrementalMode = (hasExistingConfig && isGlobal) || (hasGlobalConfig && !isGlobal);
+
+    if (canUseIncrementalMode) {
+      const incrementalMode = await question('是否使用增量配置模式？(y/N): ');
+      if (incrementalMode.toLowerCase() === 'y' || incrementalMode.toLowerCase() === 'yes') {
+        console.log('\n📋 请选择要配置的模块 (可多选，用逗号分隔):');
+        console.log('  1. openai     - OpenAI API 配置');
+        console.log('  2. git-tokens - Git 访问令牌配置');
+        console.log('  3. conan      - Conan 配置');
+        console.log('  4. wecom      - 企业微信配置');
+        console.log('  5. git        - Git 行为配置');
+        console.log('  6. mr         - 合并请求配置');
+        console.log('  all           - 配置所有模块\n');
+
+        const selectedModules = await question('选择模块 (例如: 1,5 或 openai,git): ');
+        if (selectedModules.trim()) {
+          const modules = selectedModules.split(',').map(m => m.trim().toLowerCase());
+          configModules = modules.flatMap(module => {
+            switch (module) {
+              case '1': case 'openai': return ['openai'];
+              case '2': case 'git-tokens': return ['git-tokens'];
+              case '3': case 'conan': return ['conan'];
+              case '4': case 'wecom': return ['wecom'];
+              case '5': case 'git': return ['git'];
+              case '6': case 'mr': return ['mr'];
+              case 'all': return ['openai', 'git-tokens', 'conan', 'wecom', 'git', 'mr'];
+              default: return [];
+            }
+          }).filter((v, i, arr) => arr.indexOf(v) === i); // Remove duplicates
+        }
+
+        if (configModules.length === 0) {
+          console.log('❌ 未选择任何模块，退出配置');
+          rl.close();
+          return;
+        }
+
+        console.log(`\n✅ 将配置以下模块: ${configModules.join(', ')}\n`);
+      } else {
+        // Full configuration mode
+        configModules = ['openai', 'git-tokens', 'conan', 'wecom', 'git', 'mr'];
+      }
+    } else {
+      // Full configuration mode for new configs
+      configModules = ['openai', 'git-tokens', 'conan', 'wecom', 'git', 'mr'];
+    }
     // Load existing configuration if available
     let configData: any = {
       openai: {},
@@ -846,21 +922,43 @@ export async function initConfig(isGlobal: boolean = false): Promise<void> {
       merge_request: {}
     };
 
-    // Try to load existing config file
+    // For local config, first try to load global config as base
+    if (!isGlobal && hasGlobalConfig) {
+      try {
+        const globalConfigContent = fs.readFileSync(globalConfigPath, 'utf8');
+        const globalConfig = yaml.load(globalConfigContent) as any;
+        if (globalConfig) {
+          configData = {
+            openai: globalConfig.openai || {},
+            git_access_tokens: globalConfig.git_access_tokens || {},
+            conan: globalConfig.conan || {},
+            wecom: globalConfig.wecom || {},
+            git: globalConfig.git || {},
+            merge_request: globalConfig.merge_request || {}
+          };
+          console.log('📋 已加载全局配置作为基础配置\n');
+        }
+      } catch (error) {
+        console.log('⚠️  读取全局配置文件失败，将使用空配置\n');
+      }
+    }
+
+    // Then try to load existing local/current config file to override
     if (fs.existsSync(configPath)) {
       try {
         const existingConfigContent = fs.readFileSync(configPath, 'utf8');
         const existingConfig = yaml.load(existingConfigContent) as any;
         if (existingConfig) {
+          // Merge existing config over the base config
           configData = {
-            openai: existingConfig.openai || {},
-            git_access_tokens: existingConfig.git_access_tokens || {},
-            conan: existingConfig.conan || {},
-            wecom: existingConfig.wecom || {},
-            git: existingConfig.git || {},
-            merge_request: existingConfig.merge_request || {}
+            openai: { ...configData.openai, ...(existingConfig.openai || {}) },
+            git_access_tokens: { ...configData.git_access_tokens, ...(existingConfig.git_access_tokens || {}) },
+            conan: { ...configData.conan, ...(existingConfig.conan || {}) },
+            wecom: { ...configData.wecom, ...(existingConfig.wecom || {}) },
+            git: { ...configData.git, ...(existingConfig.git || {}) },
+            merge_request: { ...configData.merge_request, ...(existingConfig.merge_request || {}) }
           };
-          console.log('📋 发现现有配置文件，将作为默认值使用\n');
+          console.log(`📋 发现现有${isGlobal ? '全局' : '本地'}配置文件，将作为默认值使用\n`);
         }
       } catch (error) {
         console.log('⚠️  读取现有配置文件失败，将创建新配置\n');
@@ -868,135 +966,164 @@ export async function initConfig(isGlobal: boolean = false): Promise<void> {
     }
 
     // OpenAI configuration
-    console.log('🤖 OpenAI 配置:');
-    const currentKey = configData.openai.key ? '已设置' : '';
-    const openaiKey = await question(`  OpenAI API 密钥 (必需)${currentKey ? ` [${currentKey}]` : ''}: `);
-    if (openaiKey.trim()) configData.openai.key = openaiKey.trim();
+    if (configModules.includes('openai')) {
+      console.log('🤖 OpenAI 配置:');
+      const currentKey = configData.openai.key ? '已设置' : '';
+      const openaiKey = await question(`  OpenAI API 密钥 (必需)${currentKey ? ` [${currentKey}]` : ''}: `);
+      if (openaiKey.trim()) configData.openai.key = openaiKey.trim();
 
-    const currentBaseUrl = configData.openai.baseUrl || 'https://api.openai.com/v1';
-    const openaiBaseUrl = await question(`  OpenAI API 地址 [${currentBaseUrl}]: `);
-    configData.openai.baseUrl = openaiBaseUrl.trim() || currentBaseUrl;
+      const currentBaseUrl = configData.openai.baseUrl || 'https://api.openai.com/v1';
+      const openaiBaseUrl = await question(`  OpenAI API 地址 [${currentBaseUrl}]: `);
+      configData.openai.baseUrl = openaiBaseUrl.trim() || currentBaseUrl;
 
-    const currentModel = configData.openai.model || 'gpt-3.5-turbo';
-    const openaiModel = await question(`  OpenAI 模型 [${currentModel}]: `);
-    configData.openai.model = openaiModel.trim() || currentModel;
+      const currentModel = configData.openai.model || 'gpt-3.5-turbo';
+      const openaiModel = await question(`  OpenAI 模型 [${currentModel}]: `);
+      configData.openai.model = openaiModel.trim() || currentModel;
+    }
 
     // Git access tokens configuration
-    console.log('\n🔑 Git 访问令牌配置:');
-    // Keep existing tokens, don't reset
-    if (!configData.git_access_tokens) {
-      configData.git_access_tokens = {};
-    }
-
-    // Show existing tokens
-    const existingHosts = Object.keys(configData.git_access_tokens);
-    if (existingHosts.length > 0) {
-      console.log('  现有配置的Git平台:');
-      existingHosts.forEach(host => {
-        console.log(`    • ${host}: 已设置`);
-      });
-      console.log('');
-    }
-
-    console.log('  您可以添加新的Git平台访问令牌或修改现有配置，直接回车跳过');
-    // Git platform tokens with loop for multiple platforms
-    while (true) {
-      const gitHost = await question('  Git 平台主机名 (如: github.com, gitlab.example.com, gitee.com，留空结束): ');
-      if (!gitHost.trim()) break;
-
-      const currentToken = configData.git_access_tokens[gitHost.trim()];
-      const tokenPrompt = currentToken
-        ? `  ${gitHost.trim()} 访问令牌 [已设置]: `
-        : `  ${gitHost.trim()} 访问令牌: `;
-
-      const gitToken = await question(tokenPrompt);
-      if (gitToken.trim()) {
-        configData.git_access_tokens[gitHost.trim()] = gitToken.trim();
-        console.log(`    ✅ 已${currentToken ? '更新' : '添加'} ${gitHost.trim()} 的访问令牌`);
+    if (configModules.includes('git-tokens')) {
+      console.log('\n🔑 Git 访问令牌配置:');
+      // Keep existing tokens, don't reset
+      if (!configData.git_access_tokens) {
+        configData.git_access_tokens = {};
       }
 
-      const continueAdding = await question('  是否继续添加其他 Git 平台令牌？(y/N): ');
-      if (continueAdding.toLowerCase() !== 'y' && continueAdding.toLowerCase() !== 'yes') {
-        break;
+      // Show existing tokens
+      const existingHosts = Object.keys(configData.git_access_tokens);
+      if (existingHosts.length > 0) {
+        console.log('  现有配置的Git平台:');
+        existingHosts.forEach(host => {
+          console.log(`    • ${host}: 已设置`);
+        });
+        console.log('');
+      }
+
+      console.log('  您可以添加新的Git平台访问令牌或修改现有配置，直接回车跳过');
+      // Git platform tokens with loop for multiple platforms
+      while (true) {
+        const gitHost = await question('  Git 平台主机名 (如: github.com, gitlab.example.com, gitee.com，留空结束): ');
+        if (!gitHost.trim()) break;
+
+        const currentToken = configData.git_access_tokens[gitHost.trim()];
+        const tokenPrompt = currentToken
+          ? `  ${gitHost.trim()} 访问令牌 [已设置]: `
+          : `  ${gitHost.trim()} 访问令牌: `;
+
+        const gitToken = await question(tokenPrompt);
+        if (gitToken.trim()) {
+          configData.git_access_tokens[gitHost.trim()] = gitToken.trim();
+          console.log(`    ✅ 已${currentToken ? '更新' : '添加'} ${gitHost.trim()} 的访问令牌`);
+        }
+
+        const continueAdding = await question('  是否继续添加其他 Git 平台令牌？(y/N): ');
+        if (continueAdding.toLowerCase() !== 'y' && continueAdding.toLowerCase() !== 'yes') {
+          break;
+        }
       }
     }
 
     // Conan configuration
-    console.log('\n📦 Conan 配置:');
-    const currentConanUrl = configData.conan.remoteBaseUrl || '';
-    const conanBaseUrl = await question(`  Conan 仓库 API 地址 (可选)${currentConanUrl ? ` [${currentConanUrl}]` : ''}: `);
-    if (conanBaseUrl.trim()) {
-      configData.conan.remoteBaseUrl = conanBaseUrl.trim();
-    } else if (!currentConanUrl) {
-      delete configData.conan.remoteBaseUrl;
-    }
+    if (configModules.includes('conan')) {
+      console.log('\n📦 Conan 配置:');
+      const currentConanUrl = configData.conan.remoteBaseUrl || '';
+      const conanBaseUrl = await question(`  Conan 仓库 API 地址 (可选)${currentConanUrl ? ` [${currentConanUrl}]` : ''}: `);
+      if (conanBaseUrl.trim()) {
+        configData.conan.remoteBaseUrl = conanBaseUrl.trim();
+      } else if (!currentConanUrl) {
+        delete configData.conan.remoteBaseUrl;
+      }
 
-    const currentConanRepo = configData.conan.remoteRepo || 'repo';
-    const conanRepo = await question(`  Conan 仓库名称 [${currentConanRepo}]: `);
-    configData.conan.remoteRepo = conanRepo.trim() || currentConanRepo;
+      const currentConanRepo = configData.conan.remoteRepo || 'repo';
+      const conanRepo = await question(`  Conan 仓库名称 [${currentConanRepo}]: `);
+      configData.conan.remoteRepo = conanRepo.trim() || currentConanRepo;
+    }
 
     // WeChat Work configuration
-    console.log('\n💬 企业微信配置:');
-    const currentWebhook = configData.wecom.webhook || '';
-    const wecomWebhook = await question(`  企业微信 Webhook 地址 (可选)${currentWebhook ? ` [已设置]` : ''}: `);
-    if (wecomWebhook.trim()) {
-      configData.wecom.webhook = wecomWebhook.trim();
-    } else if (!currentWebhook) {
-      delete configData.wecom.webhook;
-    }
+    if (configModules.includes('wecom')) {
+      console.log('\n💬 企业微信配置:');
+      const currentWebhook = configData.wecom.webhook || '';
+      const wecomWebhook = await question(`  企业微信 Webhook 地址 (可选)${currentWebhook ? ` [已设置]` : ''}: `);
+      if (wecomWebhook.trim()) {
+        configData.wecom.webhook = wecomWebhook.trim();
+      } else if (!currentWebhook) {
+        delete configData.wecom.webhook;
+      }
 
-    const currentEnable = configData.wecom.enable !== undefined ? configData.wecom.enable : true;
-    const wecomEnable = await question(`  启用企业微信通知 [${currentEnable}]: `);
-    configData.wecom.enable = wecomEnable.trim() === '' ? currentEnable : wecomEnable.trim() !== 'false';
+      const currentEnable = configData.wecom.enable !== undefined ? configData.wecom.enable : true;
+      const wecomEnable = await question(`  启用企业微信通知 [${currentEnable}]: `);
+      configData.wecom.enable = wecomEnable.trim() === '' ? currentEnable : wecomEnable.trim() !== 'false';
+    }
 
     // Git configuration
-    console.log('\n🌿 Git 配置:');
-    const currentSquash = configData.git.squashCommits !== undefined ? configData.git.squashCommits : true;
-    const squashCommits = await question(`  压缩提交 [${currentSquash}]: `);
-    configData.git.squashCommits = squashCommits.trim() === '' ? currentSquash : squashCommits.trim() !== 'false';
+    if (configModules.includes('git')) {
+      console.log('\n🌿 Git 配置:');
+      const currentSquash = configData.git.squashCommits !== undefined ? configData.git.squashCommits : true;
+      const squashCommits = await question(`  压缩提交 [${currentSquash}]: `);
+      configData.git.squashCommits = squashCommits.trim() === '' ? currentSquash : squashCommits.trim() !== 'false';
 
-    const currentRemove = configData.git.removeSourceBranch !== undefined ? configData.git.removeSourceBranch : true;
-    const removeSourceBranch = await question(`  删除源分支 [${currentRemove}]: `);
-    configData.git.removeSourceBranch = removeSourceBranch.trim() === '' ? currentRemove : removeSourceBranch.trim() !== 'false';
+      const currentRemove = configData.git.removeSourceBranch !== undefined ? configData.git.removeSourceBranch : true;
+      const removeSourceBranch = await question(`  删除源分支 [${currentRemove}]: `);
+      configData.git.removeSourceBranch = removeSourceBranch.trim() === '' ? currentRemove : removeSourceBranch.trim() !== 'false';
 
-    // Merge Request configuration
-    console.log('\n🔀 合并请求指派配置:');
-    const currentAssigneeId = configData.merge_request.assignee_id || 0;
-    const assigneeId = await question(`  单个指派人用户ID (可选，0表示取消指派) [${currentAssigneeId}]: `);
-    const parsedAssigneeId = parseInt(assigneeId.trim(), 10);
-    configData.merge_request.assignee_id = isNaN(parsedAssigneeId) ? currentAssigneeId : parsedAssigneeId;
-
-    const currentAssigneeIds = configData.merge_request.assignee_ids || [];
-    const assigneeIdsStr = currentAssigneeIds.length > 0 ? currentAssigneeIds.join(',') : '';
-    const assigneeIds = await question(`  指派人用户ID列表 (可选，逗号分隔，如: 1,2,3)${assigneeIdsStr ? ` [${assigneeIdsStr}]` : ''}: `);
-    if (assigneeIds.trim()) {
-      configData.merge_request.assignee_ids = assigneeIds.split(',').map(id => {
-        const num = parseInt(id.trim(), 10);
-        return isNaN(num) ? 0 : num;
-      }).filter(id => id >= 0);
-    } else if (!assigneeIdsStr) {
-      configData.merge_request.assignee_ids = [];
+      const currentLang = configData.git.generation_lang || 'en';
+      const generationLang = await question(`  AI生成语言 (en=英文, zh-CN=中文, ja=日文等) [${currentLang}]: `);
+      configData.git.generation_lang = generationLang.trim() || currentLang;
     }
 
-    const currentReviewerIds = configData.merge_request.reviewer_ids || [];
-    const reviewerIdsStr = currentReviewerIds.length > 0 ? currentReviewerIds.join(',') : '';
-    const reviewerIds = await question(`  审查者用户ID列表 (可选，逗号分隔，如: 1,2,3)${reviewerIdsStr ? ` [${reviewerIdsStr}]` : ''}: `);
-    if (reviewerIds.trim()) {
-      configData.merge_request.reviewer_ids = reviewerIds.split(',').map(id => {
-        const num = parseInt(id.trim(), 10);
-        return isNaN(num) ? 0 : num;
-      }).filter(id => id >= 0);
-    } else if (!reviewerIdsStr) {
-      configData.merge_request.reviewer_ids = [];
+    // Merge Request configuration
+    if (configModules.includes('mr')) {
+      console.log('\n🔀 合并请求指派配置:');
+      const currentAssigneeId = configData.merge_request.assignee_id || 0;
+      const assigneeId = await question(`  单个指派人用户ID (可选，0表示取消指派) [${currentAssigneeId}]: `);
+      const parsedAssigneeId = parseInt(assigneeId.trim(), 10);
+      configData.merge_request.assignee_id = isNaN(parsedAssigneeId) ? currentAssigneeId : parsedAssigneeId;
+
+      const currentAssigneeIds = configData.merge_request.assignee_ids || [];
+      const assigneeIdsStr = currentAssigneeIds.length > 0 ? currentAssigneeIds.join(',') : '';
+      const assigneeIds = await question(`  指派人用户ID列表 (可选，逗号分隔，如: 1,2,3)${assigneeIdsStr ? ` [${assigneeIdsStr}]` : ''}: `);
+      if (assigneeIds.trim()) {
+        configData.merge_request.assignee_ids = assigneeIds.split(',').map(id => {
+          const num = parseInt(id.trim(), 10);
+          return isNaN(num) ? 0 : num;
+        }).filter(id => id >= 0);
+      } else if (!assigneeIdsStr) {
+        configData.merge_request.assignee_ids = [];
+      }
+
+      const currentReviewerIds = configData.merge_request.reviewer_ids || [];
+      const reviewerIdsStr = currentReviewerIds.length > 0 ? currentReviewerIds.join(',') : '';
+      const reviewerIds = await question(`  审查者用户ID列表 (可选，逗号分隔，如: 1,2,3)${reviewerIdsStr ? ` [${reviewerIdsStr}]` : ''}: `);
+      if (reviewerIds.trim()) {
+        configData.merge_request.reviewer_ids = reviewerIds.split(',').map(id => {
+          const num = parseInt(id.trim(), 10);
+          return isNaN(num) ? 0 : num;
+        }).filter(id => id >= 0);
+      } else if (!reviewerIdsStr) {
+        configData.merge_request.reviewer_ids = [];
+      }
     }
 
     rl.close();
 
     // Create configuration file
-    await createConfigFile(configData, isGlobal);
+    await createConfigFile(configData, isGlobal, configModules, canUseIncrementalMode);
 
     console.log('\n✅ 配置初始化完成！');
-    console.log(`📁 配置文件已创建: ${isGlobal ? '全局配置' : '本地配置'}`);
+    if (canUseIncrementalMode && configModules.length < 6) {
+      if (isGlobal) {
+        console.log(`📁 已更新${configModules.join(', ')}模块的全局配置`);
+        console.log('💡 其他模块配置保持不变');
+      } else {
+        console.log(`📁 已创建本地配置，覆盖${configModules.join(', ')}模块`);
+        console.log('💡 其他模块将继承全局配置');
+      }
+    } else {
+      console.log(`📁 配置文件已创建: ${isGlobal ? '全局配置' : '本地配置'}`);
+      if (!isGlobal && hasGlobalConfig) {
+        console.log('💡 本地配置将覆盖全局配置的对应部分');
+      }
+    }
     console.log('💡 您可以随时手动编辑配置文件进行修改');
 
   } catch (error) {
@@ -1009,15 +1136,35 @@ export async function initConfig(isGlobal: boolean = false): Promise<void> {
 /**
  * Create configuration file
  */
-export async function createConfigFile(configData: any, isGlobal: boolean): Promise<void> {
+export async function createConfigFile(
+  configData: any,
+  isGlobal: boolean,
+  configModules: string[] = ['openai', 'git-tokens', 'conan', 'wecom', 'git', 'mr'],
+  isIncrementalMode: boolean = false
+): Promise<void> {
   // Calculate actual global config path
   const userDataDir = getUserDataDir();
   const globalConfigPath = path.join(userDataDir, 'aiflow', 'config.yaml');
   // Generate YAML content with comments
-  const yamlContent = `# AIFlow 配置文件
+  let yamlContent = '';
+
+  if (isIncrementalMode && !isGlobal && configModules.length < 6) {
+    // For incremental local config, only include selected modules
+    yamlContent = `# AIFlow 本地配置文件 (增量模式)
+# 此配置将覆盖全局配置的对应部分
 # 配置优先级: 命令行参数 > 本地配置(.aiflow/config.yaml) > 全局配置(${globalConfigPath}) > 环境变量
 
-# OpenAI API 配置 - 用于AI驱动的功能
+`;
+  } else {
+    yamlContent = `# AIFlow 配置文件
+# 配置优先级: 命令行参数 > 本地配置(.aiflow/config.yaml) > 全局配置(${globalConfigPath}) > 环境变量
+
+`;
+  }
+
+  // Add sections based on selected modules
+  if (configModules.includes('openai')) {
+    yamlContent += `# OpenAI API 配置 - 用于AI驱动的功能
 openai:
   # OpenAI API 密钥 (必需) - 用于生成提交信息和代码分析
   key: ${configData.openai.key || 'your-openai-api-key'}
@@ -1028,11 +1175,15 @@ openai:
   # OpenAI 模型名称 (必需) - 指定使用的AI模型，如 gpt-3.5-turbo, gpt-4
   model: ${configData.openai.model}
 
-# Git 访问令牌配置 - 支持多个Git托管平台
+`;
+  }
+
+  if (configModules.includes('git-tokens')) {
+    yamlContent += `# Git 访问令牌配置 - 支持多个Git托管平台
 git_access_tokens:
 ${Object.keys(configData.git_access_tokens || {}).length > 0
-      ? Object.entries(configData.git_access_tokens).map(([host, token]) => `  # ${host} 访问令牌\n  ${host}: ${token}`).join('\n\n')
-      : `  # GitHub 访问令牌 - 格式: ghp_xxxxxxxxxxxxxxxxxxxx
+        ? Object.entries(configData.git_access_tokens).map(([host, token]) => `  # ${host} 访问令牌\n  ${host}: ${token}`).join('\n\n')
+        : `  # GitHub 访问令牌 - 格式: ghp_xxxxxxxxxxxxxxxxxxxx
   # github.com: ghp_xxxxxxxxxxxxxxxxxxxxx
   
   # GitLab 访问令牌 - 格式: glpat-xxxxxxxxxxxxxxxxxxxx  
@@ -1041,7 +1192,11 @@ ${Object.keys(configData.git_access_tokens || {}).length > 0
   # Gitee 访问令牌 - 格式: gitee_xxxxxxxxxxxxxxxxxxxx
   # gitee.com: gitee_xxxxxxxxxxxxxxxxxxxxx`}
 
-# Conan 包管理器配置 - 用于C++包管理和版本更新
+`;
+  }
+
+  if (configModules.includes('conan')) {
+    yamlContent += `# Conan 包管理器配置 - 用于C++包管理和版本更新
 conan:
   # Conan 远程仓库基础URL (Conan操作时必需) - Conan包仓库的API地址
   ${configData.conan.remoteBaseUrl ? `remoteBaseUrl: ${configData.conan.remoteBaseUrl}` : '# remoteBaseUrl: https://conan.example.com'}
@@ -1049,7 +1204,11 @@ conan:
   # Conan 远程仓库名称 (可选) - 默认使用的仓库名称，默认为'repo'
   remoteRepo: ${configData.conan.remoteRepo}
 
-# 企业微信通知配置 - 用于发送操作结果通知
+`;
+  }
+
+  if (configModules.includes('wecom')) {
+    yamlContent += `# 企业微信通知配置 - 用于发送操作结果通知
 wecom:
   # 启用企业微信通知 (可选) - 是否开启通知功能，默认为false
   enable: ${configData.wecom.enable}
@@ -1057,15 +1216,26 @@ wecom:
   # 企业微信机器人Webhook地址 (可选) - 用于发送通知消息的机器人地址
   ${configData.wecom.webhook ? `webhook: ${configData.wecom.webhook}` : '# webhook: https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=your-key'}
 
-# Git 合并请求配置 - 控制MR的默认行为
+`;
+  }
+
+  if (configModules.includes('git')) {
+    yamlContent += `# Git 合并请求配置 - 控制MR的默认行为
 git:
   # 压缩提交 (可选) - 合并时是否将多个提交压缩为一个，默认为true
   squashCommits: ${configData.git.squashCommits}
   
   # 删除源分支 (可选) - 合并后是否删除源分支，默认为true
   removeSourceBranch: ${configData.git.removeSourceBranch}
+  
+  # AI生成语言 (可选) - AI生成commit message和MR描述的语言，默认为en
+  generation_lang: ${configData.git.generation_lang}
 
-# 合并请求指派配置 - 配置指派人和审查者
+`;
+  }
+
+  if (configModules.includes('mr')) {
+    yamlContent += `# 合并请求指派配置 - 配置指派人和审查者
 merge_request:
   # 单个指派人用户ID (可选) - 设置为0或留空取消指派
   assignee_id: ${configData.merge_request?.assignee_id || 0}
@@ -1076,6 +1246,7 @@ merge_request:
   # 审查者用户ID数组 (可选) - 设置为空数组不添加审查者
   reviewer_ids: ${configData.merge_request?.reviewer_ids ? JSON.stringify(configData.merge_request.reviewer_ids) : '[]'}
 `;
+  }
 
   // Determine config path
   let configPath: string;

--- a/src/services/git-platform-service.ts
+++ b/src/services/git-platform-service.ts
@@ -32,6 +32,7 @@ export interface MergeRequestOptions {
   reviewer_ids?: number[];
   squash?: boolean;
   removeSourceBranch?: boolean;
+  description?: string;
 }
 
 /**

--- a/src/services/openai-service.ts
+++ b/src/services/openai-service.ts
@@ -1,4 +1,14 @@
 import { HttpClient } from '../http/http-client.js';
+import { createLogger } from '../logger.js';
+
+/**
+ * Result of AI-generated commit information
+ */
+export interface CommitGenerationResult {
+  commit: string;
+  branch: string;
+  description: string;
+}
 
 /**
  * OpenAI API service for generating commit message and branch name
@@ -8,6 +18,7 @@ export class OpenAiService {
   private readonly apiUrl: string;
   private readonly model: string;
   private readonly http: HttpClient;
+  private readonly logger = createLogger('OpenAiService');
 
   constructor(apiKey: string, apiUrl: string, model: string, http?: HttpClient) {
     this.apiKey = apiKey;
@@ -21,12 +32,13 @@ export class OpenAiService {
     if (apiUrl.endsWith('/chat/completions')) { // trim /v1
       this.apiUrl = apiUrl.slice(0, -10);
     }
+    this.logger.info(`Initialized OpenAI service`, { apiUrl: this.apiUrl, model: this.model });
   }
 
   /**
-   * Generate commit message and branch name in English
+   * Generate commit message, branch name and MR description
    */
-  async generateCommitAndBranch(diff: string): Promise<{ commit: string; branch: string }> {
+  async generateCommitAndBranch(diff: string, language: string = 'en'): Promise<CommitGenerationResult> {
     type OpenAiResp = { choices: { message: { content: string } }[] };
 
     const body = JSON.stringify({
@@ -34,37 +46,54 @@ export class OpenAiService {
       messages: [
         {
           role: "system",
-          content: `You are an expert Git commit analyzer. Analyze the git diff and generate appropriate commit message and branch name.
+          content: `You are an expert Git commit analyzer. Analyze the git diff and generate appropriate commit message, branch name, and merge request description.
+
+LANGUAGE: Generate all content in ${this.getLanguageName(language)} (${language}). For English, use standard technical terminology. For Chinese, use professional technical Chinese. For other languages, use appropriate professional terminology.
 
 STRICT RULES:
 1. Commit message: Follow conventional commits format (type(scope): description)
    - Types: feat, fix, docs, style, refactor, test, chore
    - Keep under 72 characters
    - Use imperative mood (e.g., "add", "fix", "update")
+   - Write in specified language ${this.getLanguageName(language)} (${language})
    
-2. Branch name: MUST follow exact pattern "type/short-description"
+2. Branch name: MUST follow exact pattern "type/short-description" (ALWAYS in English)
    - REQUIRED format: {type}/{kebab-case-description}
    - Type MUST be one of: feat, fix, docs, style, refactor, test, chore
    - Description: 2-4 words maximum, separated by hyphens
    - Examples: feat/user-auth, fix/login-bug, docs/api-guide, refactor/code-cleanup
    - NO exceptions to this format
-   - Branch name MUST start with one of the allowed types followed by slash.
+   - Branch name MUST always be in English regardless of language setting
    
-3. Analyze the diff to understand:
+3. MR Description: Generate detailed merge request description in specified language ${this.getLanguageName(language)} (${language})
+   - Include "## What Changed" section describing modifications
+   - Include "## Why" section explaining the reason for changes
+   - Include "## How to Test" section with testing instructions
+   - Use appropriate formatting with markdown
+   - Be comprehensive but concise
+   - Write in specified language ${this.getLanguageName(language)} (${language})
+
+4. MR Title: Generate concise merge request title in specified language ${this.getLanguageName(language)} (${language})
+   - Include "chore" prefix for maintenance changes
+   - Use concise and descriptive title
+   - Write in specified language ${this.getLanguageName(language)} (${language})
+   
+5. Analyze the diff to understand:
    - What files are changed
    - What functionality is added/modified/removed
    - The scope/impact of changes
+   - Testing considerations
 
-CRITICAL: Return ONLY valid JSON format: {"commit":"<msg>", "branch":"<type/description>"}, don't add any other text / comments or markdown and just return the JSON object`,
+CRITICAL: Return ONLY valid JSON format: {"commit":"<msg>", "branch":"<type/description>", "description":"<detailed-mr-description>", "title":"<mr-title>"}, don't add any other text / comments or markdown wrapper and just return the JSON object`,
         },
         {
           role: "user",
-          content: `Analyze this git diff and generate commit message and branch name:\n\n${diff}`,
+          content: `Analyze this git diff and generate commit message, branch name, MR description and MR title:\n\n${diff}`,
         },
       ],
       temperature: 0.1, // Low temperature for consistent, accurate commit messages
     });
-
+    this.logger.debug(`OpenAI request body: ${body}`);
     const resp = await this.http.requestJson<OpenAiResp>(
       `${this.apiUrl}/chat/completions`,
       "POST",
@@ -75,7 +104,7 @@ CRITICAL: Return ONLY valid JSON format: {"commit":"<msg>", "branch":"<type/desc
       body
     );
     const rawContent = resp.choices[0].message.content;
-    console.debug("Raw AI response:", rawContent);
+    this.logger.debug(`OpenAI response: ${rawContent}`);
 
     // Clean up the response - remove markdown code blocks if present
     let cleanContent = rawContent.trim();
@@ -89,10 +118,41 @@ CRITICAL: Return ONLY valid JSON format: {"commit":"<msg>", "branch":"<type/desc
 
     try {
       const content = JSON.parse(cleanContent);
-      return { commit: content.commit, branch: content.branch };
+      return { 
+        commit: content.commit, 
+        branch: content.branch, 
+        description: content.description || '' 
+      } as CommitGenerationResult;
     } catch (error) {
-      console.error("Failed to parse AI response:", cleanContent);
+      this.logger.error("Failed to parse AI response:", cleanContent);
       throw new Error(`Invalid JSON response from AI: ${error}`);
     }
+  }
+
+  /**
+   * Get language display name for prompt
+   */
+  private getLanguageName(language: string): string {
+    if(!language) {
+      return 'English';
+    }
+    language = language.toLowerCase();
+    const languageMap: Record<string, string> = {
+      'en': 'English',
+      'zh-cn': 'Chinese (Simplified)',
+      'zh-tw': 'Chinese (Traditional)',
+      'zhcn': 'Chinese (Simplified)',
+      'zhtw': 'Chinese (Traditional)',
+      'ja': 'Japanese',
+      'ko': 'Korean',
+      'fr': 'French',
+      'de': 'German',
+      'es': 'Spanish',
+      'ru': 'Russian',
+      'pt': 'Portuguese',
+      'it': 'Italian'
+    };
+    
+    return languageMap[language] || 'English';
   }
 }

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -32,7 +32,7 @@ export class Shell {
    */
   run(command: string): string {
     const startTime = Date.now();
-    
+    this.logger.debug(`Executing command: ----\n${command}\n----`);
     try {
       // For multiline commands, use a different approach with base64 encoding
       if (command.includes('\n') || command.includes('@\'') || command.includes('\'@')) {


### PR DESCRIPTION
## What Changed
- 在配置文件中新增 `git.generation_lang` 选项，用于指定AI生成提交信息和MR描述的语言
- 更新了AI服务逻辑，支持根据配置的语言生成相应语言的内容
- 修改了配置初始化流程，支持增量配置模式，允许用户只更新特定模块
- 改进了GitHub和GitLab平台服务，支持设置MR/Pull Request的描述内容
- 统一了日志输出方式，使用logger替代console.log

## Why
为了提升AIFlow工具的国际化支持能力，让用户可以根据需要生成不同语言的提交信息和合并请求描述。同时通过增量配置模式简化了配置管理，特别是在有全局配置和本地配置共存的场景下。

## How to Test
1. 使用 `-ggl` 或 `--git-generation-lang` 参数指定生成语言，如 `aiflow -ggl zh-CN`
2. 在配置文件中设置 `git.generation_lang: zh-CN` 来测试中文生成效果
3. 测试增量配置模式：先创建全局配置，然后运行本地配置初始化，选择增量模式并只更新git模块
4. 验证生成的MR/Pull Request是否包含正确的描述内容