### PR TITLE
Potential fix for code scanning alert no. 9: Incomplete URL substring sanitization

### DIFF
--- a/src/services/github-platform-service.ts
+++ b/src/services/github-platform-service.ts
@@ -211,7 +211,13 @@ export class GithubPlatformService extends GitPlatformService {
    * For GitHub Enterprise, use hostname/api/v3
    */
   private getApiBaseUrl(): string {
-    if (this.baseUrl.includes('github.com')) {
+    let hostname: string;
+    try {
+      hostname = new URL(this.baseUrl).hostname;
+    } catch {
+      hostname = '';
+    }
+    if (hostname === 'github.com') {
       return 'https://api.github.com';
     } else {
       // GitHub Enterprise


### PR DESCRIPTION
Potential fix for [https://github.com/HeiSir2014/git-aiflow/security/code-scanning/9](https://github.com/HeiSir2014/git-aiflow/security/code-scanning/9)

To fix the problem, we should parse `this.baseUrl` as a URL, and perform an **exact** check on the `hostname` property, rather than using a substring check. Specifically, we should check if the parsed hostname is exactly `"github.com"`. This prevents false positives like `evil-github.com` or `github.com.evil.com`.  
We'll modify the `getApiBaseUrl()` method to parse `this.baseUrl` with the `URL` constructor (available natively in Node.js), extract the `hostname`, and do a strict equality check. We'll also add a fallback or error handling if the URL is invalid.

Required changes:
- Import nothing new (URL is built-in).
- In `getApiBaseUrl()`, replace the substring check with parsing and hostname check.

No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
