### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/src/services/git-service.ts
+++ b/src/services/git-service.ts
@@ -100,7 +100,7 @@ ${escapedMessage}
       this.shell.run(powershellCommand);
     } else {
       // For single line messages, use standard escaping
-      const escapedMessage = message.replace(/"/g, '\\"').replace(/`/g, '\\`');
+      const escapedMessage = message.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/`/g, '\\`');
       this.shell.run(`git commit -m "${escapedMessage}"`);
     }
   }


### PR DESCRIPTION
Potential fix for [https://github.com/HeiSir2014/git-aiflow/security/code-scanning/1](https://github.com/HeiSir2014/git-aiflow/security/code-scanning/1)

To fix the incomplete escaping, we should extend the current escaping logic to also escape backslash (`\`) characters. The optimal solution is to escape backslashes before escaping quotes or other metacharacters: otherwise, added backslashes could themselves be double-escaped. This should be performed using a global regular expression to replace all instances of `\` with `\\`, prior to escaping other relevant characters. Only line 103 in `src/services/git-service.ts` needs to be changed, and no new method or library imports are strictly required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
