### PR TITLE
chore: update package version to 1.0.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "git-aiflow",
-  "version": "1.0.13",
+  "version": "1.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "git-aiflow",
-      "version": "1.0.13",
+      "version": "1.0.16",
       "license": "MIT",
       "dependencies": {
         "clipboardy": "^4.0.0",


### PR DESCRIPTION
## What Changed

更新了项目的版本号从 1.0.13 到 1.0.16。此更改涉及 `package-lock.json` 文件中的两个位置：根对象和 packages[""] 对象的 version 字段。

## Why

进行此版本更新是为了反映项目的最新发布状态。随着新功能的添加或错误修复，需要递增版本号以保持版本控制的一致性和准确性。

## How to Test

1. 检查 `package-lock.json` 文件中的 version 字段是否已正确更新为 1.0.16
2. 验证项目构建过程是否正常运行
3. 确认依赖项解析没有问题