### PR TITLE
chore(workflows): 统一使用master分支作为默认分支

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -19,9 +19,9 @@
 ```yaml
 on:
   push:
-    branches: [ main, master, develop ]
+    branches: [ master ]
   pull_request:
-    branches: [ main, master, develop ]
+    branches: [ master ]
   workflow_dispatch:
 ```
 

--- a/.github/workflows/changelog-update.yml
+++ b/.github/workflows/changelog-update.yml
@@ -2,7 +2,7 @@ name: Update Changelog
 
 on:
   push:
-    branches: [main]
+    branches: [master]
     paths:
       - 'package.json'
   workflow_dispatch:
@@ -196,7 +196,7 @@ jobs:
               repo: context.repo.repo,
               title: `📝 Update CHANGELOG.md for version ${{ steps.version.outputs.version }}`,
               head: `changelog-update-${{ steps.version.outputs.version }}`,
-              base: 'main',
+              base: 'master',
               body: `## 📝 Changelog Update
 
               This PR automatically updates the CHANGELOG.md file for version ${{ steps.version.outputs.version }}.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: [ main, master, develop ]
+    branches: [ master ]
   pull_request:
-    branches: [ main, master, develop ]
+    branches: [ master ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,14 +2,14 @@ name: Documentation
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [ master ]
     paths:
       - 'src/**'
       - 'README*.md'
       - 'docs/**'
       - '.github/workflows/docs.yml'
   pull_request:
-    branches: [ main, master ]
+    branches: [ master ]
     paths:
       - 'src/**'
       - 'README*.md'
@@ -247,7 +247,7 @@ jobs:
           ## Available Workflows
           
           ### CI/CD Pipeline (`ci.yml`)
-          - **Trigger**: Push/PR to main branches
+          - **Trigger**: Push/PR to master branches
           - **Purpose**: Build, test, and validate code quality
           - **Jobs**:
             - Lint and type checking
@@ -267,7 +267,7 @@ jobs:
             - Post-release validation
           
           ### Code Quality (`quality.yml`)
-          - **Trigger**: Push/PR to main branches, daily schedule
+          - **Trigger**: Push/PR to master branches, daily schedule
           - **Purpose**: Comprehensive code quality and security analysis
           - **Jobs**:
             - CodeQL security analysis
@@ -285,7 +285,7 @@ jobs:
             - Vulnerability assessment
           
           ### Performance Monitoring (`performance.yml`)
-          - **Trigger**: Push to main, PR, daily schedule
+          - **Trigger**: Push to master, PR, daily schedule
           - **Purpose**: Monitor and track performance metrics
           - **Jobs**:
             - Build performance benchmarking
@@ -370,7 +370,7 @@ jobs:
           
           For developers working on AIFlow:
           
-          1. **Getting Started**: See the main README for setup instructions
+          1. **Getting Started**: See the master README for setup instructions
           2. **API Reference**: Check the [API documentation](api/) for detailed type information
           3. **CLI Usage**: Refer to [CLI documentation](cli/) for command details
           4. **Contributing**: See GitHub Actions [workflows](workflows/) for CI/CD information
@@ -379,7 +379,7 @@ jobs:
           
           If you need help:
           
-          1. Check the [troubleshooting section](../README.md#故障排除) in the main README
+          1. Check the [troubleshooting section](../README.md#故障排除) in the master README
           2. Search existing [issues](https://github.com/HeiSir2014/git-aiflow/issues)
           3. Create a new [issue](https://github.com/HeiSir2014/git-aiflow/issues/new)
           
@@ -411,7 +411,7 @@ jobs:
           echo "🔗 Checking Documentation Links"
           echo "=============================="
           
-          # Check main README
+          # Check master README
           if [ -f README.md ]; then
             echo "Checking README.md links:"
             markdown-link-check README.md --config .github/mlc-config.json || echo "Some links may be broken"
@@ -510,7 +510,7 @@ jobs:
     name: Publish Documentation
     runs-on: ubuntu-latest
     needs: [validate-documentation, generate-api-docs, validate-links]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     
     steps:
       - name: Checkout code

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -2,9 +2,9 @@ name: Performance Monitoring
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [ master ]
   pull_request:
-    branches: [ main, master ]
+    branches: [ master ]
   schedule:
     # Run daily at 6 AM UTC
     - cron: '0 6 * * *'

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -2,9 +2,9 @@ name: Code Quality and Security
 
 on:
   push:
-    branches: [ main, master, develop ]
+    branches: [ master ]
   pull_request:
-    branches: [ main, master, develop ]
+    branches: [ master ]
   schedule:
     # Run daily at 2 AM UTC
     - cron: '0 2 * * *'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -428,7 +428,7 @@ jobs:
               repo: context.repo.repo,
               title: `🔄 Sync package.json version to ${{ needs.validate-release.outputs.version }}`,
               head: `sync-version-${{ needs.validate-release.outputs.version }}`,
-              base: 'main',
+              base: 'master',
               body: `## 📦 Version Synchronization
 
               This PR automatically syncs the \`package.json\` version to match the release tag.


### PR DESCRIPTION
## 变更内容

本次修改统一了所有GitHub Actions工作流文件中的分支配置：

- 移除了对 `main` 和 `develop` 分支的引用
- 将所有触发条件统一设置为 `master` 分支
- 更新了相关文档中的分支说明
- 修改了PR创建时的目标分支为 `master`

## 变更原因

项目决定采用 `master` 作为默认主分支，需要统一所有CI/CD工作流的配置，确保：
- 代码推送和PR触发条件的一致性
- 自动化流程的正确执行
- 文档说明的准确性

## 测试方法

1. 推送代码到 `master` 分支，验证工作流是否正常触发
2. 创建针对 `master` 分支的PR，验证CI检查是否执行
3. 检查文档生成和发布流程是否正常工作
4. 验证版本发布和变更日志更新流程