### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete string escaping or encoding

### DIFF
--- a/src/shell.ts
+++ b/src/shell.ts
@@ -134,7 +134,7 @@ export class Shell {
 
   private runWindowsSimpleCommand(command: string, startTime: number): string {
     // Single line command - use original method
-    const pwsh_command = `"[Console]::OutputEncoding = [Text.UTF8Encoding]::UTF8; ${command.replace(/"/g, '\\"')}"`;
+    const pwsh_command = `"[Console]::OutputEncoding = [Text.UTF8Encoding]::UTF8; ${command.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
     const pwsh_args = [...this.shellArgs, pwsh_command];
 
     logger.debug(`Executing command: \n----\n${command}\n----`);


### PR DESCRIPTION
Potential fix for [https://github.com/HeiSir2014/git-aiflow/security/code-scanning/3](https://github.com/HeiSir2014/git-aiflow/security/code-scanning/3)

To correctly escape the command string when embedding it in a PowerShell command literal in double quotes, *both* double quotes and backslashes need to be escaped. This should be done by replacing every backslash with two backslashes, then every double quote with a backslash-double quote, ensuring the proper order (backslashes first). The best fix is to change line 137's `command.replace(/"/g, '\\"')` to  
`command.replace(/\\/g, '\\\\').replace(/"/g, '\\"')`.  
Edit only line 137 in src/shell.ts, leaving surrounding code unchanged. No additional imports or dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
