### PR TITLE
chore(workflows): 统一使用ACCESS_TOKEN替代GITHUB_TOKEN

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -299,7 +299,7 @@ on:
 NPM_TOKEN=npm_xxxxxxxxxxxxxxxx
 
 # GitHub Token (自动提供)
-GITHUB_TOKEN=ghp_xxxxxxxxxxxx
+ACCESS_TOKEN=ghp_xxxxxxxxxxxx
 ```
 
 ### CodeQL 配置
@@ -383,7 +383,7 @@ permissions:
 
 #### 4. **权限错误**
 ```bash
-# 检查 GITHUB_TOKEN 权限
+# 检查 ACCESS_TOKEN 权限
 # 验证分支保护规则
 # 确认 Secrets 配置
 ```

--- a/.github/workflows/changelog-update.yml
+++ b/.github/workflows/changelog-update.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.ACCESS_TOKEN }}
           fetch-depth: 0
 
       - name: Setup Node.js

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -329,7 +329,7 @@ jobs:
           
           Required secrets for workflows:
           - `NPM_TOKEN`: For NPM publishing (release workflow)
-          - `GITHUB_TOKEN`: Automatically provided by GitHub
+          - `ACCESS_TOKEN`: Automatically provided by GitHub
           
           ## Workflow Artifacts
           

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -345,7 +345,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.ACCESS_TOKEN }}
           fetch-depth: 0
 
       - name: Setup Node.js


### PR DESCRIPTION
## What Changed

更新了GitHub Actions工作流配置，将所有对`GITHUB_TOKEN`的引用统一改为`ACCESS_TOKEN`：

- 修改了`.github/workflows/README.md`文档中的示例配置
- 更新了`changelog-update.yml`工作流中的token引用
- 修改了`docs.yml`工作流中的文档说明
- 更新了`release.yml`工作流中的token引用

## Why

为了保持工作流配置的一致性，避免使用不同的token变量名称造成混淆。统一使用`ACCESS_TOKEN`作为标准命名，提高代码的可维护性和可读性。

## How to Test

1. 验证所有工作流文件中的token引用都已正确更新
2. 确保对应的GitHub Secrets中已配置`ACCESS_TOKEN`
3. 运行相关的工作流测试，确认token访问权限正常
4. 检查文档中的示例配置是否与实际代码保持一致