### PR TITLE
chore(workflows): 添加GitHub Pages部署权限配置

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -512,6 +512,11 @@ jobs:
     needs: [validate-documentation, generate-api-docs, validate-links]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -533,6 +538,8 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN}}
 
       - name: Create deployment summary
         run: |


### PR DESCRIPTION
## What Changed

在 `.github/workflows/docs.yml` 文件中添加了GitHub Pages部署所需的权限配置：
- 添加了 `permissions` 配置块，包含 `contents: read`、`pages: write` 和 `id-token: write` 权限
- 在部署步骤中添加了 `GITHUB_TOKEN` 环境变量配置

## Why

这些更改是为了确保GitHub Actions工作流具有正确的权限来部署文档到GitHub Pages。GitHub最近更新了安全策略，需要明确声明工作流所需的权限，特别是对于Pages部署需要 `id-token: write` 权限来进行安全认证。

## How to Test

1. 将更改推送到master分支
2. 观察GitHub Actions工作流是否正常运行
3. 确认文档成功部署到GitHub Pages
4. 验证部署过程中没有权限相关的错误