### PR TITLE
更新 npmignore 配置并修复正则表达式转义问题

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -11,6 +11,7 @@ node_modules/
 *.test.js
 *.test.ts
 test/
+dist/test/
 
 # Development scripts and configs
 .env
@@ -18,6 +19,7 @@ test/
 
 # Git
 .git/
+.github/
 .gitignore
 
 # IDE files
@@ -75,6 +77,7 @@ coverage/
 
 # Local configuration examples (but keep global example)
 .aiflow/
+.aiflow-conan/
 
 # Source maps (optional - include if you want them for debugging)
 dist/**/*.map
@@ -83,5 +86,9 @@ dist/**/*.d.ts.map
 # wiki
 wiki/
 doc/
+docs/
+
+# logs
+logs/
 
 # Keep only essentials for the package

--- a/src/services/conandata-service.ts
+++ b/src/services/conandata-service.ts
@@ -1,5 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import _ from 'lodash';
+const { escapeRegExp } = _;
 
 /**
  * Service for managing conandata.yml file updates
@@ -37,9 +39,10 @@ export class ConanDataService {
   updatePackageVersion(packageName: string, newVersion: string): string {
     const content = this.readContent();
     
+    const safePackageName = escapeRegExp(packageName);
     // Pattern to match package references like "- zterm/1.0.0.24"
     const packagePattern = new RegExp(
-      `^(\\s*-\\s+)${packageName}\/[^\\s]+`,
+      `^(\\s*-\\s+)${safePackageName}\/[^\\s]+`,
       'gm'
     );
     
@@ -86,9 +89,10 @@ export class ConanDataService {
   getCurrentVersion(packageName: string): string | null {
     const content = this.readContent();
     
+    const safePackageName = escapeRegExp(packageName);
     // Pattern to extract version from "- packageName/version"
     const versionPattern = new RegExp(
-      `^\\s*-\\s+${packageName}\/([^\\s]+)`,
+      `^\\s*-\\s+${safePackageName}\/([^\\s]+)`,
       'm'
     );
     

--- a/src/services/conanlock-service.ts
+++ b/src/services/conanlock-service.ts
@@ -140,7 +140,7 @@ export class ConanLockService {
   getCurrentLockInfo(packageName: string): ConanLockEntry | null {
     const content = this.readContent();
     
-    const safePackageName = _.escapeRegExp(packageName);
+    const safePackageName = escapeRegExp(packageName);
     // Pattern to find package lock entry
     const lockPattern = new RegExp(
       `"(${safePackageName}\/[^#]+#[^%]+%[^"]+)"`, 'g'


### PR DESCRIPTION
## What Changed
- 更新 .npmignore 文件，添加 dist/test/、.github/、.aiflow-conan/、docs/、logs/ 到忽略列表
- 在 conandata-service.ts 中导入 lodash 并使用 escapeRegExp 方法对包名进行正则转义
- 统一 conanlock-service.ts 中的正则转义方法调用方式

## Why
- 防止不必要的文件和目录被发布到 npm 包中
- 修复包名包含特殊字符时的正则表达式匹配问题，提高代码健壮性
- 保持代码一致性，统一使用相同的转义方法

## How to Test
- 运行 npm pack 验证 .npmignore 配置是否正确排除指定文件
- 使用包含特殊字符（如 .、*、+ 等）的包名测试版本更新和获取功能
- 验证正则表达式匹配是否正常工作，不会因特殊字符导致匹配失败