### PR TITLE
添加 DeepSeek Chat V3.1 Free 模型支持

### DIFF
--- a/src/services/openai-service.ts
+++ b/src/services/openai-service.ts
@@ -388,6 +388,7 @@ export class OpenAiService {
       'deepseekv3': 128000,
       'deepseekv31': 128000,
       'deepseek-coder-v2': 128000,
+      'deepseek/deepseek-chat-v3.1:free': 163800,
 
       // Qwen models
       'qwen-turbo': 8192,


### PR DESCRIPTION
## 变更内容
- 在 OpenAI 服务中添加了 deepseek-chat-v3.1:free 模型的上下文长度配置
- 将该模型的上下文长度设置为 163800 tokens

## 变更原因
- 需要支持新发布的 DeepSeek Chat V3.1 Free 模型
- 确保系统能够正确处理该模型的上下文窗口限制

## 测试方法
1. 调用 OpenAI 服务时使用 model='deepseek/deepseek-chat-v3.1:free'
2. 验证上下文长度限制是否正确应用为 163800 tokens
3. 测试长文本处理功能是否正常工作