### PR TITLE
修复 Git 服务中相同分支处理逻辑

### DIFF
--- a/src/services/git-service.ts
+++ b/src/services/git-service.ts
@@ -1076,6 +1076,11 @@ export class GitService {
           }
         }
 
+        // Skip if the clean branch is the same as current branch
+        if (cleanBranch === currentBranch) {
+          continue;
+        }
+
         // Only consider this branch if the clean branch name exists locally
         if (!localBranches.includes(cleanBranch)) {
           continue;


### PR DESCRIPTION
## 变更内容
- 在 `src/services/git-service.ts` 文件中，新增了一个条件判断逻辑
- 当 `cleanBranch` 与 `currentBranch` 相同时，跳过当前循环的后续处理

## 变更原因
- 避免在分支清理过程中对当前所在分支进行不必要的操作
- 提高代码健壮性，防止潜在的逻辑错误或重复处理

## 测试方法
- 运行相关单元测试以确保无回归问题
- 手动验证在不同分支状态下执行 Git 操作的行为是否符合预期