### PR TITLE
OpenAI 服务：添加请求头和用法统计配置

### DIFF
--- a/src/services/openai-service.ts
+++ b/src/services/openai-service.ts
@@ -127,6 +127,10 @@ export class OpenAiService {
       ,
       maxRetries: 3,
       timeout: 300000,
+      defaultHeaders: {
+        'HTTP-Referer': 'https://github.com/HeiSir2014/git-aiflow',
+        'X-Title': 'Git-AIFlow',
+      },
     });
     
     logger.info(`Initialized OpenAI service`, { 
@@ -337,8 +341,7 @@ export class OpenAiService {
       // Create a test prompt that approaches but doesn't exceed the limit
       const testTokens = Math.floor(contextLimit * 0.8); // Use 80% of limit for safety
       const testContent = 'x'.repeat(testTokens * 4); // Approximate 4 chars per token
-
-      const response = await this.client.chat.completions.create({
+      const testBody = {
         model: this.model,
         messages: [
           {
@@ -351,8 +354,14 @@ export class OpenAiService {
           }
         ],
         max_tokens: 10, // Minimal response
-        temperature: 0
-      });
+        temperature: 0,
+        extra_body: {
+          usage: {
+            include: true,
+          },
+        }
+      } as any;
+      const response = await this.client.chat.completions.create(testBody);
 
       // If we get a response, the context limit is supported
       return response.choices && response.choices.length > 0;
@@ -950,6 +959,12 @@ ${batchSummaries}`,
       model: this.model,
       messages: messages as OpenAI.Chat.ChatCompletionMessageParam[],
       temperature: 0.1
+    };
+
+    (requestParams as any).extra_body = {
+      usage: {
+        include: true,
+      },
     };
 
     // Add reasoning support for compatible models (if supported by the API)


### PR DESCRIPTION
## 变更内容

- 在 OpenAI 服务初始化中添加默认请求头配置：
  - `HTTP-Referer`: https://github.com/HeiSir2014/git-aiflow
  - `X-Title`: Git-AIFlow
- 在上下文限制测试和批量摘要生成中添加 `extra_body` 配置：
  - 启用用法统计包含功能 (`usage.include: true`)
- 重构上下文限制测试逻辑，使用 `testBody` 变量存储请求参数

## 变更原因

- 添加默认请求头以便更好地标识请求来源和项目信息
- 启用用法统计功能以监控 API 调用消耗情况
- 提高代码可读性和维护性，通过变量存储请求参数

## 测试方法

1. 运行 OpenAI 服务初始化测试，验证默认请求头是否正确设置
2. 执行上下文限制测试功能，确认用法统计功能正常工作
3. 测试批量摘要生成功能，检查请求参数是否包含用法统计配置