### PR TITLE
chore: sync package.json version to 1.0.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.34] - 2025-09-28
+
+### Added
+- Release version 1.0.34
+
+### Changed
+- Updated package version to 1.0.34
+
+### Fixed
+- Version synchronization between package.json and release tag
+
+
 ## [1.0.33] - 2025-09-27
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "git-aiflow",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "git-aiflow",
-      "version": "1.0.33",
+      "version": "1.0.34",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.63.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-aiflow",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "description": "🚀 An AI-powered workflow automation tool for effortless Git-based development, combining smart GitLab/GitHub merge & pull request creation with Conan package management.",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
- Updated package.json version from 1.0.33 to 1.0.34
- Updated CHANGELOG.md with release information
- This ensures consistency between release tag and package version
- Auto-generated by release workflow