### PR TITLE
添加 Grok 模型支持到 OpenAI 服务

### DIFF
--- a/src/services/openai-service.ts
+++ b/src/services/openai-service.ts
@@ -430,6 +430,9 @@ export class OpenAiService {
       'deepseek-coder-v2': 128000,
       'deepseek/deepseek-chat-v3.1:free': 163800,
 
+      // Grok models
+      'x-ai/grok-4-fast:free': 2000000,
+
       // Qwen models
       'qwen-turbo': 8192,
       'qwen-plus': 32768,
@@ -553,6 +556,10 @@ export class OpenAiService {
       { pattern: /(^|\/|:)yi/i, limit: 4096, description: 'Other Yi variants' },
       { pattern: /(^|\/|:)glm[-_]?4/i, limit: 128000, description: 'GLM-4 variants' },
       { pattern: /(^|\/|:)chatglm/i, limit: 8192, description: 'ChatGLM variants' },
+
+      // Grok variants (support model names with provider prefix)
+      { pattern: /(^|\/|:)x[-_]?ai[-_]?grok[-_]?4[-_]?fast/i, limit: 2000000, description: 'Grok 4 Fast variants' },
+      { pattern: /(^|\/|:)x[-_]?ai/i, limit: 2000000, description: 'Other Grok variants' },
     ];
 
     // Try pattern matching


### PR DESCRIPTION
## 变更内容
- 在模型上下文限制映射中添加 Grok-4-Fast 模型支持，上下文限制为 2,000,000 tokens
- 添加 Grok 模型变体的正则表达式模式匹配规则，支持带提供商前缀的模型名称

## 变更原因
- 扩展 OpenAI 兼容服务对 Grok 系列模型的支持
- 确保 Grok 模型能够正确识别并使用其特有的上下文长度限制

## 测试方法
1. 使用 Grok-4-Fast 模型进行 API 调用
2. 验证上下文长度限制是否正确应用为 2,000,000 tokens
3. 测试不同格式的 Grok 模型名称（如 x-ai/grok-4-fast:free）是否能够正确匹配