### PR TITLE
更新 package-lock.json 添加 peer 依赖标识

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -245,6 +245,7 @@
       "integrity": "sha512-IbKooQVqUBrlzWTi79E8Fw78l8k1RNtlDDNWsFZs7XonuQSJ8oNYfEeclhprUldXISRMLzBpILuKgPlIxm+/Yw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.14.0"
       }
@@ -1523,6 +1524,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
## 变更内容
- 在 `package-lock.json` 文件中，为两个依赖项添加了 `"peer": true` 属性
- 具体涉及的依赖项为 `undici-types` 和 `tsc`/`tsserver`（TypeScript 相关包）

## 变更原因
- 此变更是为了正确标识某些依赖项为 peer dependencies，这通常用于库项目中声明与宿主项目共享的依赖关系
- 添加 `peer: true` 属性有助于确保这些依赖项在安装时被正确处理，避免版本冲突或重复安装

## 测试方法
- 运行 `npm install` 或 `yarn install` 确保依赖安装无错误
- 检查 `node_modules` 中相关依赖的安装结构是否符合预期
- 执行项目构建或测试命令，确保功能未受影响