### PR TITLE
feat: 添加 OpenAI 模型上下文 token 可配置支持

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,202 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+git-aiflow is an AI-powered workflow automation CLI tool for Git-based development. It consists of two main commands:
+- `aiflow` - General Git merge/pull request automation with AI-generated commits
+- `aiflow-conan` - Specialized tool for Conan C++ package version updates
+
+The project is built with TypeScript using ES modules and targets Node.js >= 22.0.0.
+
+## Key Commands
+
+### Build & Development
+```bash
+npm run build              # Compile TypeScript to dist/
+npm run dev               # Run aiflow in watch mode
+npm run dev-conan         # Run aiflow-conan in watch mode
+npm run clean             # Remove dist/ directory
+```
+
+### Running Tests
+Individual test files must be run directly with ts-node:
+```bash
+npm run test:config                  # Configuration loading tests
+npm run test:git-all                 # All Git service tests
+npm run test:git-new-methods         # Git service new methods
+npm run test:git-base-branch         # Base branch detection
+npm run test:git-branch-ops          # Branch operations
+npm run test:git-branch-graph        # Branch graph analysis
+npm run test:conan                   # Conan service tests
+npm run test:openai-parse            # OpenAI JSON parsing
+npm run test:shell-multiline         # Shell multiline tests
+```
+
+**Note**: There is no unified test runner like `npm test` - use specific test scripts above.
+
+### Debugging
+```bash
+npm run aiflow:debug           # Run aiflow with Node debugger on port 9229
+npm run aiflow:debug-brk       # Run with breakpoint on start
+npm run aiflow-conan:debug     # Run aiflow-conan with debugger on port 9230
+npm run aiflow-conan:debug-brk # Run with breakpoint on start
+```
+
+### Running the Tools
+```bash
+npm run aiflow             # Run the main aiflow tool
+npm run aiflow-conan       # Run the conan package updater
+```
+
+## Architecture
+
+### Service Layer Pattern
+
+The codebase follows a service-oriented architecture with clear separation of concerns:
+
+**Git Platform Abstraction** (`src/services/git-platform-service.ts`):
+- Abstract base class `GitPlatformService` defines the contract for all Git platforms
+- `GitPlatformServiceFactory` automatically detects the Git platform (GitLab/GitHub) by:
+  1. Parsing the Git remote URL hostname
+  2. Probing API endpoints (`/api/v4/version` for GitLab, `/api/v3` for GitHub)
+  3. Creating the appropriate platform-specific service
+- Concrete implementations:
+  - `GitlabPlatformService` - GitLab API integration
+  - `GithubPlatformService` - GitHub API integration
+
+**Core Services**:
+- `GitService` (singleton) - Git operations via shell commands, including:
+  - Remote URL parsing (SSH/HTTP formats)
+  - Base branch detection (main > master > develop priority)
+  - Branch operations and status checking
+  - Base URL extraction with automatic protocol detection
+- `OpenAiService` - AI-powered commit message and branch name generation with:
+  - Diff chunking for large changesets (max 16K tokens per chunk)
+  - Support for OpenAI reasoning models (o1, o3 series)
+  - Structured JSON output parsing
+  - Multi-language generation support
+- `ConanService` - Conan package registry API client
+- `WecomNotifier` - Enterprise WeChat webhook notifications
+- `HttpClient` - Centralized HTTP operations with logging
+
+**Configuration System** (`src/config.ts`):
+- Multi-layered config priority: CLI args > local file (`.aiflow/config.yaml`) > global file (`~/.config/aiflow/config.yaml` or `%APPDATA%/aiflow/config.yaml`) > environment variables
+- `ConfigLoader` class handles merging and validation
+- Interactive config initialization via `aiflow init` and `aiflow init --global`
+- Git access tokens are stored per-hostname in `git_access_tokens` map
+
+**Application Classes** (`src/aiflow-app.ts`, `src/aiflow-conan-app.ts`):
+- `BaseAiflowApp` - Abstract base with common workflow logic
+  - Service initialization
+  - Interactive file selection UI
+  - Configuration validation
+- `AiflowApp` - General merge request automation
+- `AiflowConanApp` - Conan package update automation
+
+### Key Design Patterns
+
+1. **Singleton Pattern**: `GitService` and `Shell` use singleton pattern to maintain consistent state
+2. **Factory Pattern**: `GitPlatformServiceFactory` creates appropriate platform services
+3. **Template Method**: `BaseAiflowApp` defines workflow template, subclasses implement specifics
+4. **Strategy Pattern**: Platform-specific services implement common interface differently
+
+### File Structure Conventions
+
+```
+src/
+├── services/           # Business logic services (Git, OpenAI, Conan, etc.)
+├── http/              # HTTP client utilities
+├── utils/             # Helper utilities (string, color, update checker, etc.)
+├── test/              # Test files (*.test.ts)
+├── config.ts          # Configuration management
+├── logger.ts          # Winston-based logging system
+├── shell.ts           # Shell command execution wrapper
+├── aiflow-app.ts      # Main aiflow application
+└── aiflow-conan-app.ts # Conan-specific application
+```
+
+## Configuration & Environment
+
+**Configuration Files**:
+- Local: `.aiflow/config.yaml` (project-specific)
+- Global: `~/.config/aiflow/config.yaml` (macOS/Linux) or `%APPDATA%/aiflow/config.yaml` (Windows)
+- Example: `config.example.yaml` at project root
+
+**Important Configuration Options**:
+- `openai.max_context_tokens` (optional): Manual configuration of model's maximum context window
+  - If not specified, defaults to 8192 tokens
+  - Users should consult their model's documentation for accurate context limits
+  - Common values: gpt-3.5-turbo (4096/16384), gpt-4 (8192), gpt-4-turbo/4o (128000), claude-3.5-sonnet (200000)
+  - System prompt and response tokens are automatically reserved (see `calculateReservedTokens` in openai-service.ts:639)
+
+**Environment Variables**:
+The tool supports legacy environment variables but config files are preferred:
+- `OPENAI_KEY`, `OPENAI_BASE_URL`, `OPENAI_MODEL`, `OPENAI_MAX_CONTEXT_TOKENS`
+- `GIT_ACCESS_TOKEN_<HOST>` (e.g., `GIT_ACCESS_TOKEN_GITHUB_COM`)
+- `CONAN_REMOTE_BASE_URL`, `CONAN_REMOTE_REPO`
+- `WECOM_WEBHOOK`, `WECOM_ENABLE`
+- Git platform tokens require appropriate scopes (see README.md)
+
+**Logging**:
+- Winston-based structured logging with file rotation
+- Logs stored in platform-specific directories:
+  - macOS: `~/Library/Application Support/aiflow/logs/`
+  - Linux: `~/.config/aiflow/logs/`
+  - Windows: `%APPDATA%\aiflow\logs/`
+- Files: `aiflow.log` (all levels), `error.log` (errors only)
+- Max 10MB per file, keeps 5 files
+
+## AI Generation Details
+
+The `OpenAiService` generates:
+1. **Commit Messages**: Follows Conventional Commits format (feat/fix/chore/docs/refactor)
+2. **Branch Names**: Sanitized English descriptions with special chars removed
+3. **MR Descriptions**: Structured markdown with summary and test plan
+
+**Language Support**: Configurable via `git.generation_lang` in config (en, zh-CN, zh-TW, ja, ko, fr, de, es, ru, pt, it)
+
+**Context Window Management**:
+- Uses user-configured `max_context_tokens` (defaults to 8192 if not specified)
+- Automatically reserves tokens for system prompt (~1200) and response (~1500) plus safety buffer (5-15% depending on model size)
+- For diffs exceeding available context, automatically splits into batches and merges results
+- No automatic model detection - users must configure context limits based on their model documentation
+
+## Common Workflows
+
+### Standard MR Creation
+1. User stages files or tool prompts for interactive selection
+2. Tool detects target branch (main/master/develop)
+3. AI generates commit message and branch name from diff
+4. Creates feature branch, commits, pushes to remote
+5. Creates merge/pull request with assignees/reviewers
+6. Sends WeCom notification (if configured)
+7. Copies MR URL to clipboard
+
+### Commit-Only Mode
+Same as above but stops after step 4 (no MR creation). Triggered with `--commit-only` or `-co` flag.
+
+### Conan Package Update
+1. Fetches latest package version from Conan registry
+2. Updates `conandata.yml` and `conan.win.lock`
+3. Follows standard MR creation workflow with package-specific commit message
+
+## Platform-Specific Details
+
+**TypeScript/ESM**:
+- All imports must include `.js` extension (e.g., `import './foo.js'` even though source is `foo.ts`)
+- Uses `"type": "module"` in package.json
+- No CommonJS require() - use ES6 imports only
+
+**CLI Entry Points**:
+- `dist/aiflow-app.js` and `dist/aiflow-conan-app.js` have shebang and are made executable in postbuild
+- Uses `ts-node/esm` loader for development (`npm run node-ts`)
+
+**Dependencies**:
+- OpenAI SDK: Used for chat completions and reasoning models
+- Anthropic SDK: Available but not currently used in main workflow
+- Winston: Structured logging
+- js-yaml: YAML config parsing
+- chalk: Terminal colors
+- clipboardy: Cross-platform clipboard

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -5,12 +5,24 @@
 openai:
   # OpenAI API 密钥 (必需) - 用于生成提交信息和代码分析
   key: your-openai-api-key
-  
+
   # OpenAI API 基础URL (必需) - API请求的端点地址
   baseUrl: https://api.openai.com/v1
-  
+
   # OpenAI 模型名称 (必需) - 指定使用的AI模型，如 gpt-3.5-turbo, gpt-4
   model: gpt-3.5-turbo
+
+  # 模型最大上下文token数 (可选) - 手动指定模型的最大上下文长度，默认为8192
+  # 常见模型推荐值：
+  #   gpt-3.5-turbo: 4096 或 16384 (取决于具体版本)
+  #   gpt-4: 8192
+  #   gpt-4-turbo/gpt-4o: 128000
+  #   gpt-4o-mini: 128000
+  #   claude-3.5-sonnet: 200000
+  #   deepseek-v3: 64000
+  #   qwen2.5: 32768
+  # 💡 提示：查看您使用的模型文档以确定正确的上下文长度
+  max_context_tokens: 16384
 
 # Git 访问令牌配置 - 支持多个Git托管平台
 git_access_tokens:

--- a/src/aiflow-app.ts
+++ b/src/aiflow-app.ts
@@ -43,7 +43,8 @@ export abstract class BaseAiflowApp {
       getConfigValue(this.config, 'openai.key', '') || '',
       getConfigValue(this.config, 'openai.baseUrl', 'https://api.openai.com/v1') || 'https://api.openai.com/v1',
       getConfigValue(this.config, 'openai.model', 'gpt-3.5-turbo') || 'gpt-3.5-turbo',
-      getConfigValue(this.config, 'openai.reasoning', false) || false
+      getConfigValue(this.config, 'openai.reasoning', false) || false,
+      getConfigValue(this.config, 'openai.max_context_tokens', undefined)
     );
 
     // Create platform-specific service using factory (fully automatic)
@@ -830,10 +831,12 @@ isMain && GitAutoMrApp.main().catch(async (error) => {
 // Handle termination signals
 process.on('SIGTERM', async () => {
   logger.info('Received SIGTERM signal, shutting down service...');
+  await processExit(0);
 });
 
 process.on('SIGINT', async () => {
   logger.info('Received SIGINT signal, shutting down service...');
+  await processExit(130); // Standard exit code for SIGINT (128 + 2)
 });
 
 // Handle uncaught exceptions

--- a/src/config.ts
+++ b/src/config.ts
@@ -72,6 +72,7 @@ export interface AiflowConfig {
     key?: string;
     baseUrl?: string;
     model?: string;
+    max_context_tokens?: number;
     reasoning?: boolean | {
       enabled?: boolean;
       effort?: 'high' | 'medium' | 'low';
@@ -189,6 +190,7 @@ export class ConfigLoader {
       'OPENAI_KEY': 'openai.key',
       'OPENAI_BASE_URL': 'openai.baseUrl',
       'OPENAI_MODEL': 'openai.model',
+      'OPENAI_MAX_CONTEXT_TOKENS': 'openai.max_context_tokens',
       'OPENAI_REASONING': 'openai.reasoning',
       'CONAN_REMOTE_BASE_URL': 'conan.remoteBaseUrl',
       'CONAN_REMOTE_REPO': 'conan.remoteRepo',
@@ -217,8 +219,15 @@ export class ConfigLoader {
       if (envValue !== undefined) {
         let parsedValue = this.parseEnvValue(envValue);
 
+        // Handle number fields
+        if (configPath === 'openai.max_context_tokens') {
+          if (typeof parsedValue === 'string') {
+            const num = parseInt(parsedValue, 10);
+            parsedValue = isNaN(num) ? undefined : num;
+          }
+        }
         // Handle array fields for merge request configuration
-        if (configPath === 'merge_request.assignee_ids' || configPath === 'merge_request.reviewer_ids') {
+        else if (configPath === 'merge_request.assignee_ids' || configPath === 'merge_request.reviewer_ids') {
           if (typeof parsedValue === 'string') {
             // Parse comma-separated string to number array
             parsedValue = parsedValue.split(',').map(id => {
@@ -646,6 +655,11 @@ export function parseCliArgs(args: string[]): Partial<AiflowConfig> {
         config.openai = { ...config.openai, model: value };
         i++;
         break;
+      case 'openai-max-context-tokens':
+        const maxTokens = parseInt(value, 10);
+        config.openai = { ...config.openai, max_context_tokens: isNaN(maxTokens) ? undefined : maxTokens };
+        i++;
+        break;
       case 'openai-reasoning':
         config.openai = { ...config.openai, reasoning: value !== 'false' };
         i++;
@@ -726,10 +740,11 @@ export function parseCliArgs(args: string[]): Partial<AiflowConfig> {
  */
 function getShortArgMapping(shortKey: string): string {
   const shortArgMap: Record<string, string> = {
-    // OpenAI shortcuts (OpenAI Key, OpenAI Base Url, OpenAI Model, OpenAI Reasoning)
+    // OpenAI shortcuts (OpenAI Key, OpenAI Base Url, OpenAI Model, OpenAI Max Context Tokens, OpenAI Reasoning)
     'ok': 'openai-key',
     'obu': 'openai-base-url',
     'om': 'openai-model',
+    'omct': 'openai-max-context-tokens',
     'or': 'openai-reasoning',
 
     // Git access token shortcuts (Git Access Token)
@@ -774,6 +789,7 @@ OpenAI 配置 - AI功能支持:
   -ok, --openai-key <key>               OpenAI API密钥 (必需，用于AI生成提交信息)
   -obu, --openai-base-url <url>         OpenAI API地址 (必需，API请求端点)
   -om, --openai-model <model>           OpenAI模型 (必需，如gpt-3.5-turbo、gpt-4)
+  -omct, --openai-max-context-tokens <num>  模型最大上下文token数 (可选，默认8192)
   -or, --openai-reasoning <bool>        启用推理模式 (可选，适用于o1等推理模型)
 
 Git 访问令牌配置 - 多平台支持:

--- a/src/services/git-service.ts
+++ b/src/services/git-service.ts
@@ -27,6 +27,9 @@ export class GitService {
   private static readonly instances = new Map<string, GitService>();
   private remote_name?: string;
   private remote_urls = new Map<string, string>();
+  private _repoRootCache?: string; // Cache for repository root
+  private _userNameCache?: string; // Cache for git user.name
+  private _userEmailCache?: string; // Cache for git user.email
 
   private constructor(shell?: Shell) {
     this.shell = shell || Shell.instance();
@@ -303,12 +306,37 @@ export class GitService {
     }
   }
 
+  /**
+   * Get git user name (cached after first call)
+   */
   getUserName(): string {
+    if (this._userNameCache) {
+      return this._userNameCache;
+    }
     try {
-      return StringUtil.sanitizeName(this.shell.runProcess("git", "config", "user.name"));
+      this._userNameCache = StringUtil.sanitizeName(this.shell.runProcess("git", "config", "user.name"));
+      return this._userNameCache;
     } catch (error) {
       logger.warn('Failed to get git user name:', error);
-      return 'unknown-user';
+      this._userNameCache = 'unknown-user';
+      return this._userNameCache;
+    }
+  }
+
+  /**
+   * Get git user email (cached after first call)
+   */
+  getUserEmail(): string {
+    if (this._userEmailCache) {
+      return this._userEmailCache;
+    }
+    try {
+      this._userEmailCache = this.shell.runProcess("git", "config", "user.email").trim();
+      return this._userEmailCache;
+    } catch (error) {
+      logger.warn('Failed to get git user email:', error);
+      this._userEmailCache = 'unknown@example.com';
+      return this._userEmailCache;
     }
   }
 
@@ -317,22 +345,23 @@ export class GitService {
    * @param options Diff options
    * @returns Git diff output
    */
-  getDiff(options: { 
-    includeBinary?: boolean; 
+  getDiff(options: {
+    includeBinary?: boolean;
     nameOnly?: boolean;
   } = {}): string {
     try {
       const { includeBinary = false, nameOnly = false } = options;
-      
+      const repoRoot = this.getRepositoryRoot();
+
       if (nameOnly) {
-        return this.shell.runProcess("git", "diff", "--cached", "--name-only");
+        return this.shell.runProcess("git", "-C", repoRoot, "diff", "--cached", "--name-only");
       }
-      
+
       if (includeBinary) {
         // Force treat all files as text (may produce unreadable output for binary files)
-        return this.shell.runProcess("git", "diff", "--cached", "--text");
+        return this.shell.runProcess("git", "-C", repoRoot, "diff", "--cached", "--text");
       }
-      
+
       // Default behavior: Exclude binary files to avoid unreadable output
       return this.getDiffExcludingBinary();
     } catch (error) {
@@ -347,31 +376,34 @@ export class GitService {
    */
   private getDiffExcludingBinary(): string {
     try {
+      const repoRoot = this.getRepositoryRoot();
+
       // Get list of staged files
       const stagedFiles = this.getChangedFiles();
-      
+
       if (stagedFiles.length === 0) {
         return '';
       }
-      
+
       // Filter out binary files
       const textFiles: string[] = [];
-      
+
       for (const file of stagedFiles) {
         if (!this.isBinaryFile(file, { cached: true })) {
           textFiles.push(file);
         }
       }
-      
+
       if (textFiles.length === 0) {
         return 'All staged files are binary files.';
       }
-      
+
       // Get diff for text files only
-      return this.shell.runProcess("git", "diff", "--cached", "--", ...textFiles);
+      return this.shell.runProcess("git", "-C", repoRoot, "diff", "--cached", "--", ...textFiles);
     } catch (error) {
       logger.warn('Error filtering binary files, falling back to default diff:', error);
-      return this.shell.runProcess("git", "diff", "--cached");
+      const repoRoot = this.getRepositoryRoot();
+      return this.shell.runProcess("git", "-C", repoRoot, "diff", "--cached");
     }
   }
 
@@ -381,16 +413,18 @@ export class GitService {
    * @param options Options for binary detection
    * @returns True if file is binary, false otherwise
    */
-  private isBinaryFile(filePath: string, options: { 
-    cached?: boolean; 
+  private isBinaryFile(filePath: string, options: {
+    cached?: boolean;
     branchComparison?: string;
   } = {}): boolean {
     try {
       const { cached = true, branchComparison } = options;
-      
+
       // Use git to check if file is binary using runWithExitCode for better error handling
-      const args: string[] = ["diff"];
-      
+      // Git diff syntax: git diff [options] <commit> [--] [<path>...]
+      // Options MUST come before the commit range
+      const args: string[] = ["diff", "--numstat"];
+
       if (branchComparison) {
         // For branch comparison
         args.push(branchComparison);
@@ -399,9 +433,9 @@ export class GitService {
         args.push("--cached");
       }
       // For unstaged changes, no additional flag needed
-      
-      args.push("--numstat", "--", filePath);
-      
+
+      args.push("--", filePath);
+
       const result = this.shell.runWithExitCode("git", ...args);
       
       // Check if command succeeded
@@ -528,16 +562,22 @@ export class GitService {
    * @returns Diff output or null if failed
    */
   private tryGetDiffBetweenBranches(baseBranch: string, targetBranch: string, extraArgs: string[] = []): string | null {
+    const repoRoot = this.getRepositoryRoot();
+
     // Try different branch reference formats
+    // IMPORTANT: Use two-dot (..) syntax first, which shows all changes from base to target
+    // Three-dot (...) syntax shows changes from merge-base to target, which is NOT what we want
     const branchFormats = [
-      `${baseBranch}...${targetBranch}`,
-      `${this.getRemoteName()}/${baseBranch}...${targetBranch}`,
       `${baseBranch}..${targetBranch}`,
-      `${this.getRemoteName()}/${baseBranch}..${targetBranch}`
+      `${this.getRemoteName()}/${baseBranch}..${targetBranch}`,
+      `${baseBranch}...${targetBranch}`,
+      `${this.getRemoteName()}/${baseBranch}...${targetBranch}`
     ];
 
     for (const format of branchFormats) {
-      const args = ["diff", ...extraArgs, format];
+      // Git diff syntax: git diff [options] <commit> [--] [<path>...]
+      // The commit range MUST come before the file paths
+      const args = ["-C", repoRoot, "diff", format, ...extraArgs];
       const result = this.shell.runWithExitCode("git", ...args);
       
       if (result.success && result.exitCode === 0) {
@@ -570,7 +610,7 @@ export class GitService {
       const textFiles: string[] = [];
       
       for (const file of changedFiles) {
-        if (!this.isBinaryFile(file, { branchComparison: `${baseBranch}...${targetBranch}` })) {
+        if (!this.isBinaryFile(file, { branchComparison: `${baseBranch}..${targetBranch}` })) {
           textFiles.push(file);
         }
       }
@@ -606,20 +646,23 @@ export class GitService {
         return [];
       }
 
+      const repoRoot = this.getRepositoryRoot();
+
       // First try with remote prefix for base branch
       let filesOutput = '';
       let success = false;
-      
+
       // Try different branch reference formats
+      // IMPORTANT: Use two-dot (..) syntax first, which shows all changes from base to target
       const branchFormats = [
-        `${baseBranch}...${targetBranch}`,
-        `${this.getRemoteName()}/${baseBranch}...${targetBranch}`,
         `${baseBranch}..${targetBranch}`,
-        `${this.getRemoteName()}/${baseBranch}..${targetBranch}`
+        `${this.getRemoteName()}/${baseBranch}..${targetBranch}`,
+        `${baseBranch}...${targetBranch}`,
+        `${this.getRemoteName()}/${baseBranch}...${targetBranch}`
       ];
 
       for (const format of branchFormats) {
-        const result = this.shell.runWithExitCode("git", "diff", "--name-only", format);
+        const result = this.shell.runWithExitCode("git", "-C", repoRoot, "diff", "--name-only", format);
         
         if (result.success && result.exitCode === 0) {
           filesOutput = result.output.trim();
@@ -647,24 +690,29 @@ export class GitService {
 
   /**
    * Add specific file to staging area
-   * @param filePath File path to add
+   * @param filePath File path to add (relative to repository root or absolute)
    */
   addFile(filePath: string): void {
     logger.info(`Adding file: ${filePath}`);
-    this.shell.runProcess("git", "add", "-f", filePath);
+    // Use git -C to execute from repository root, ensuring paths are resolved correctly
+    // regardless of where the command is executed from
+    const repoRoot = this.getRepositoryRoot();
+    this.shell.runProcess("git", "-C", repoRoot, "add", "-f", filePath);
   }
 
   /**
    * Add multiple files to staging area
-   * @param filePaths Array of file paths to add
+   * @param filePaths Array of file paths to add (relative to repository root or absolute)
    */
   addFiles(filePaths: string[], batchSize = 1000): void {
     if (filePaths.length === 0) return;
 
     logger.info(`Adding ${filePaths.length} files in batches of ${batchSize}`);
+    const repoRoot = this.getRepositoryRoot();
     for (let i = 0; i < filePaths.length; i += batchSize) {
       const batch = filePaths.slice(i, i + batchSize);
-      this.shell.runProcess("git", "add", "-f", ...batch);
+      // Use git -C to execute from repository root
+      this.shell.runProcess("git", "-C", repoRoot, "add", "-f", ...batch);
     }
   }
 
@@ -674,7 +722,8 @@ export class GitService {
    */
   createBranch(branchName: string): void {
     logger.info(`Creating branch: ${branchName}`);
-    this.shell.runProcess("git", "checkout", "-b", branchName);
+    const repoRoot = this.getRepositoryRoot();
+    this.shell.runProcess("git", "-C", repoRoot, "checkout", "-b", branchName);
   }
 
   /**
@@ -684,6 +733,8 @@ export class GitService {
   commit(message: string): void {
     logger.info('Committing changes...');
     logger.debug(`Commit message: ${message.substring(0, 100)}${message.length > 100 ? '...' : ''}`);
+    const repoRoot = this.getRepositoryRoot();
+
     if (!message.includes("\n")) {
       // 单行 commit
       const escapedMessage = message
@@ -691,11 +742,11 @@ export class GitService {
         .replace(/"/g, '\\"')
         .replace(/`/g, "\\`");
 
-      this.shell.runProcess("git", "commit", "-m", escapedMessage);
+      this.shell.runProcess("git", "-C", repoRoot, "commit", "-m", escapedMessage);
       return;
     }
     const lines = message.split(/\r?\n/).map(line => line.trimEnd());
-    const args: string[] = ["commit"];
+    const args: string[] = ["-C", repoRoot, "commit"];
     for (const line of lines) {
       args.push("-m", line);
     }
@@ -708,7 +759,8 @@ export class GitService {
    */
   push(branchName: string): void {
     logger.info(`Pushing branch: ${branchName}`);
-    this.shell.runProcess("git", "push", "-u", this.getRemoteName(), branchName);
+    const repoRoot = this.getRepositoryRoot();
+    this.shell.runProcess("git", "-C", repoRoot, "push", "-u", this.getRemoteName(), branchName);
   }
 
   /**
@@ -729,7 +781,8 @@ export class GitService {
 
   getChangedFiles(limit?: number): string[] {
     try {
-      const output = this.shell.runProcess("git", "diff", "--cached", "--name-only").trim();
+      const repoRoot = this.getRepositoryRoot();
+      const output = this.shell.runProcess("git", "-C", repoRoot, "diff", "--cached", "--name-only").trim();
       if (!output) {
         return [];
       }
@@ -746,9 +799,15 @@ export class GitService {
 
   /**
    * Get git repository root directory
+   * Result is cached after first call for performance
    */
   getRepositoryRoot(): string {
-    return this.shell.runProcess("git", "rev-parse", "--show-toplevel").trim();
+    if (this._repoRootCache) {
+      return this._repoRootCache;
+    }
+    this._repoRootCache = this.shell.runProcess("git", "rev-parse", "--show-toplevel").trim();
+    logger.debug(`Repository root cached: ${this._repoRootCache}`);
+    return this._repoRootCache;
   }
 
   /**
@@ -1215,7 +1274,8 @@ export class GitService {
    * Check if repository has uncommitted changes
    */
   hasUncommittedChanges(): boolean {
-    const status = this.shell.runProcess("git", "status", "--porcelain").trim();
+    const repoRoot = this.getRepositoryRoot();
+    const status = this.shell.runProcess("git", "-C", repoRoot, "status", "--porcelain").trim();
     return status.length > 0;
   }
 
@@ -1223,7 +1283,8 @@ export class GitService {
    * Check if repository has staged changes
    */
   hasStagedChanges(): boolean {
-    const status = this.shell.runProcess("git", "diff", "--cached", "--name-only").trim();
+    const repoRoot = this.getRepositoryRoot();
+    const status = this.shell.runProcess("git", "-C", repoRoot, "diff", "--cached", "--name-only").trim();
     return status.length > 0;
   }
 
@@ -1233,7 +1294,8 @@ export class GitService {
    */
   status(): GitFileStatus[] {
     try {
-      const statusOutput = this.shell.runProcess("git", "status", "--short", "--ignore-submodules", "--porcelain", "--untracked-files=all");
+      const repoRoot = this.getRepositoryRoot();
+      const statusOutput = this.shell.runProcess("git", "-C", repoRoot, "status", "--short", "--ignore-submodules", "--porcelain", "--untracked-files=all");
 
       if (!statusOutput) {
         return [];
@@ -1386,7 +1448,7 @@ export class GitService {
 
       // User information
       const userName = this.getUserName();
-      const userEmail = this.shell.runProcess("git", "config", "user.email").trim();
+      const userEmail = this.getUserEmail();
       logger.info(`Git User: ${userName} <${userEmail}>`);
 
     } catch (error) {
@@ -1398,109 +1460,110 @@ export class GitService {
 
   /**
    * Get the most likely parent branch of the current branch
+   * Tries multiple strategies to find the base branch:
+   * 1. Check upstream tracking branch
+   * 2. Check merge-base with common branches (main, master, develop)
+   * 3. Fallback to common branch names if they exist in remote
+   *
    * @returns Base branch name or null if not found or in detached HEAD
    */
   getBaseBranch(): string | null {
     try {
       const currentBranch = this.getCurrentBranch();
-      if (!currentBranch || currentBranch === 'HEAD') return null;
-
-      const remotes = this.shell
-        .runProcess("git", "remote")
-        .trim()
-        .split('\n')
-        .map(r => r.trim())
-        .filter(Boolean);
-
-      const logGraph = this.shell.runProcess(
-        "git",
-        "log",
-        "--graph",
-        "--oneline",
-        "--decorate",
-        "--all",
-        "--simplify-by-decoration"
-      );
-      const lines = logGraph.split('\n');
-
-      const normalizeRef = (r: string | undefined): string | null => {
-        if (!r) return null;
-        let ref = r.trim();
-        if (!ref) return null;
-        if (ref.startsWith('tag:')) return null;
-        const arrowMatch = ref.match(/->\s*(.+)$/);
-        if (arrowMatch) return arrowMatch[1].trim();
-        return ref;
-      };
-
-      let foundCurrentBranch = false;
-      let currentBranchColumn = 0;
-      
-      for (const line of lines) {
-        const match = line.match(/\((.*?)\)/);
-        if (!match) continue;
-
-        const rawRefs = match[1].split(',').map(r => r.trim()).filter(Boolean);
-        const normalizedRefs = rawRefs.map(r => normalizeRef(r)).filter(Boolean) as string[];
-
-        // Check if this line mentions the current branch
-        const mentionsCurrent = normalizedRefs.some(r =>
-          r === currentBranch || r.endsWith(`/${currentBranch}`)
-        );
-
-        if (mentionsCurrent) {
-          foundCurrentBranch = true;
-          currentBranchColumn = line.indexOf('*');
-          continue; // Skip the line that contains current branch
-        }
-
-        // Only look for candidates after we've found the current branch
-        if (!foundCurrentBranch) continue;
-
-        const candidateRaw = rawRefs.find(r => {
-          const nr = normalizeRef(r);
-          if (!nr) return false;
-          if (nr === currentBranch) return false;
-          if (nr === 'HEAD') return false;
-          if (r.startsWith('tag:')) return false;
-          if (r === 'origin/HEAD') return false;
-          return true;
-        });
-
-        if (!candidateRaw) continue;
-
-        let candidate = normalizeRef(candidateRaw)!;
-        let candidateColumn = line.indexOf('*');
-        if (candidateColumn === -1) {
-          continue;
-        }
-        if (candidateColumn > currentBranchColumn) {
-          continue;
-        }
-
-        for (const remote of remotes) {
-          const prefix = `${remote}/`;
-          if (candidate.startsWith(prefix)) {
-            candidate = candidate.slice(prefix.length);
-            break;
-          }
-        }
-
-        if (candidate === currentBranch) continue;
-
-        // Check if candidate exists in remote using accurate remote branch detection
-        if (!this.hasRemoteBranch(candidate)) {
-          logger.debug(`Skipped candidate '${candidate}' because it does not exist in remote.`);
-          continue;
-        }
-
-        logger.debug(`Detected base branch: ${candidate}`);
-        return candidate;
+      if (!currentBranch || currentBranch === 'HEAD') {
+        logger.debug('Not on a valid branch (detached HEAD or empty)');
+        return null;
       }
 
+      const repoRoot = this.getRepositoryRoot();
+      const remoteName = this.getRemoteName();
+
+      // Strategy 1: Check if branch has an upstream tracking branch
+      try {
+        const upstream = this.shell.runProcess(
+          "git", "-C", repoRoot, "rev-parse", "--abbrev-ref", `${currentBranch}@{upstream}`
+        ).trim();
+
+        if (upstream && upstream !== currentBranch) {
+          // upstream format: "origin/main" or "upstream/develop"
+          // Extract branch name without remote prefix
+          const upstreamBranch = upstream.split('/').slice(1).join('/');
+
+          // Verify the branch exists in remote
+          if (upstreamBranch && this.hasRemoteBranch(upstreamBranch)) {
+            logger.debug(`Base branch from upstream: ${upstreamBranch}`);
+            return upstreamBranch;
+          }
+        }
+      } catch (error) {
+        // No upstream configured, try other strategies
+        logger.debug('No upstream tracking branch configured');
+      }
+
+      // Strategy 2: Find merge-base with common branches
+      const commonBranches = ['main', 'master', 'develop', 'dev', 'trunk'];
+
+      for (const candidateBranch of commonBranches) {
+        // Skip if candidate is the current branch
+        if (candidateBranch === currentBranch) continue;
+
+        // Check if candidate exists in remote
+        if (!this.hasRemoteBranch(candidateBranch)) {
+          logger.debug(`Candidate '${candidateBranch}' does not exist in remote, skipping`);
+          continue;
+        }
+
+        try {
+          // Check if there's a merge-base (common ancestor)
+          const mergeBase = this.shell.runProcess(
+            "git", "-C", repoRoot, "merge-base", "HEAD", `${remoteName}/${candidateBranch}`
+          ).trim();
+
+          if (mergeBase) {
+            // Check if current branch has commits beyond the merge-base
+            const currentCommit = this.shell.runProcess(
+              "git", "-C", repoRoot, "rev-parse", "HEAD"
+            ).trim();
+
+            // If current HEAD is different from merge-base, this candidate is a valid base
+            if (currentCommit !== mergeBase) {
+              // Verify that merge-base is an ancestor of the candidate branch
+              // This ensures we branched from this candidate
+              try {
+                this.shell.runProcess(
+                  "git", "-C", repoRoot, "merge-base", "--is-ancestor", mergeBase, `${remoteName}/${candidateBranch}`
+                );
+                // If command succeeded (exit code 0), merge-base is an ancestor
+                logger.debug(`Found base branch via merge-base: ${candidateBranch}`);
+                return candidateBranch;
+              } catch (ancestorError) {
+                // Not an ancestor, try next candidate
+                logger.debug(`Merge-base is not an ancestor of '${candidateBranch}', skipping`);
+                continue;
+              }
+            }
+          }
+        } catch (error) {
+          // No merge-base or error, try next candidate
+          logger.debug(`No valid merge-base with '${candidateBranch}': ${error}`);
+          continue;
+        }
+      }
+
+      // Strategy 3: Fallback to first available common branch in remote
+      for (const fallbackBranch of commonBranches) {
+        if (fallbackBranch === currentBranch) continue;
+
+        if (this.hasRemoteBranch(fallbackBranch)) {
+          logger.debug(`Fallback to common branch: ${fallbackBranch}`);
+          return fallbackBranch;
+        }
+      }
+
+      logger.debug('Could not determine base branch');
       return null;
     } catch (error) {
-      logger.error('Error determining base branch from log graph:', error);
+      logger.error('Error determining base branch:', error);
       return null;
     }
   }
@@ -1561,12 +1624,28 @@ export class GitService {
   }
 
   static instance(): GitService {
-    const pwd = process.cwd();
-    if (GitService.instances.get(pwd)) {
-      return GitService.instances.get(pwd)!;
+    // Use git repository root as the cache key instead of process.cwd()
+    // This ensures the same instance is used regardless of which subdirectory
+    // the command is run from
+    let repoRoot: string;
+    try {
+      const shell = Shell.instance();
+      repoRoot = shell.runProcess("git", "rev-parse", "--show-toplevel").trim();
+
+      // Normalize path separators for consistent caching
+      repoRoot = repoRoot.replace(/\\/g, '/');
+    } catch (error) {
+      // If not in a git repo, fall back to process.cwd()
+      repoRoot = process.cwd().replace(/\\/g, '/');
+      logger.warn('Not in a git repository, using current working directory');
+    }
+
+    if (GitService.instances.get(repoRoot)) {
+      return GitService.instances.get(repoRoot)!;
     }
     const gitService = new GitService();
-    GitService.instances.set(pwd, gitService);
+    GitService.instances.set(repoRoot, gitService);
+    logger.debug(`Created GitService instance for repository: ${repoRoot}`);
     return gitService;
   }
 }

--- a/src/services/openai-service.ts
+++ b/src/services/openai-service.ts
@@ -102,19 +102,18 @@ export class OpenAiService {
   private readonly client: OpenAI;
   private readonly model: string;
   private readonly reasoning: boolean | ReasoningConfig;
+  private readonly maxContextTokens: number;
 
-  /** Cache for storing detected context limits by model name */
-  private static readonly contextLimitCache = new Map<string, number>();
-  
   /** Cache for the latest throughput statistics */
   private lastThroughputStats: ThroughputStats | null = null;
-  
+
   /** History of throughput statistics (limited to last 10 requests) */
   private throughputHistory: ThroughputStats[] = [];
 
-  constructor(apiKey: string, apiUrl: string, model: string, reasoning: boolean | ReasoningConfig = false) {
+  constructor(apiKey: string, apiUrl: string, model: string, reasoning: boolean | ReasoningConfig = false, maxContextTokens?: number) {
     this.model = model;
     this.reasoning = reasoning;
+    this.maxContextTokens = maxContextTokens ?? 8192; // Default to 8K tokens if not specified
     
     // Initialize OpenAI client
     this.client = new OpenAI({
@@ -133,10 +132,11 @@ export class OpenAiService {
       },
     });
     
-    logger.info(`Initialized OpenAI service`, { 
-      baseURL: this.client.baseURL, 
-      model: this.model, 
-      reasoning: this.reasoning 
+    logger.info(`Initialized OpenAI service`, {
+      baseURL: this.client.baseURL,
+      model: this.model,
+      maxContextTokens: this.maxContextTokens,
+      reasoning: this.reasoning
     });
   }
 
@@ -178,15 +178,15 @@ export class OpenAiService {
         language = 'en';
       }
 
-      // Detect model context limit with adaptive strategy
-      const contextLimit = await this.detectContextLimit();
+      // Use configured context limit
+      const contextLimit = this.maxContextTokens;
       // Dynamically adjust reserved tokens based on model
       const RESERVED_TOKENS = this.calculateReservedTokens(contextLimit);
       const availableTokens = contextLimit - RESERVED_TOKENS;
 
       // Estimate token count for the diff
       const diffTokens = this.estimateTokenCount(diff);
-      logger.info(`Estimated diff tokens: ${diffTokens}, available tokens: ${availableTokens}`);
+      logger.info(`Estimated diff tokens: ${diffTokens}, available tokens: ${availableTokens}, context limit: ${contextLimit}`);
 
       // Use direct processing for small diffs
       if (diffTokens <= availableTokens) {
@@ -283,297 +283,6 @@ export class OpenAiService {
     } as CommitGenerationResult;
   }
 
-  /**
-   * Detect the context length limit for the current model.
-   * Supports various AI models including OpenAI, DeepSeek, Qwen, Kimi, Ollama, etc.
-   * Also handles model variants with similar context limits.
-   * 
-   * @returns Promise resolving to the token limit for the model
-   */
-  private async detectContextLimit(): Promise<number> {
-    // Return cached result if available
-    if (OpenAiService.contextLimitCache.has(this.model)) {
-      return OpenAiService.contextLimitCache.get(this.model)!;
-    }
-
-    try {
-      const limit = this.getModelContextLimit(this.model);
-      logger.debug(`Using context limit for model ${this.model}: ${limit} tokens`);
-
-      // Cache the result
-      OpenAiService.contextLimitCache.set(this.model, limit);
-      return limit;
-    } catch (error) {
-      logger.warn(`Failed to detect context limit for model ${this.model}, attempting reverse detection:`, error);
-
-      // Try reverse detection with progressively larger context sizes
-      const reverseLimits = [1024 * 1024, 512 * 1024, 256 * 1024, 128 * 1024, 64 * 1024, 32 * 1024, 16 * 1024, 8 * 1024, 4 * 1024];
-      for (const testLimit of reverseLimits) {
-        try {
-          const success = await this.testContextLimit(testLimit);
-          if (success) {
-            logger.info(`Reverse detection successful: model ${this.model} supports ${testLimit} tokens`);
-            OpenAiService.contextLimitCache.set(this.model, testLimit);
-            return testLimit;
-          }
-        } catch (testError) {
-          logger.debug(`Context limit test failed for ${testLimit} tokens:`, testError);
-          continue;
-        }
-      }
-
-      // Fallback to a more reasonable default for modern models
-      const FALLBACK_LIMIT = 8192; // More reasonable default for modern LLMs
-      logger.warn(`Reverse detection failed, using fallback limit: ${FALLBACK_LIMIT}`);
-      OpenAiService.contextLimitCache.set(this.model, FALLBACK_LIMIT);
-      return FALLBACK_LIMIT;
-    }
-  }
-
-  /**
-   * Test if a model can handle a specific context limit by making a small API call.
-   * 
-   * @param contextLimit The context limit to test
-   * @returns Promise resolving to true if the limit is supported
-   */
-  private async testContextLimit(contextLimit: number): Promise<boolean> {
-    try {
-      // Create a test prompt that approaches but doesn't exceed the limit
-      const testTokens = Math.floor(contextLimit * 0.8); // Use 80% of limit for safety
-      const testContent = 'x'.repeat(testTokens * 4); // Approximate 4 chars per token
-      const testBody = {
-        model: this.model,
-        messages: [
-          {
-            role: "system",
-            content: "You are a helpful assistant. Respond with 'OK'."
-          },
-          {
-            role: "user",
-            content: `Test message: ${testContent.substring(0, Math.min(testContent.length, 1000))}...` // Truncate for logging
-          }
-        ],
-        max_tokens: 10, // Minimal response
-        temperature: 0,
-        extra_body: {
-          usage: {
-            include: true,
-          },
-        }
-      } as any;
-      const response = await this.client.chat.completions.create(testBody);
-
-      // If we get a response, the context limit is supported
-      return response.choices && response.choices.length > 0;
-    } catch (error: any) {
-      // Check if error is context-related
-      const errorMessage = error.message?.toLowerCase() || '';
-      const isContextError = errorMessage.includes('context') ||
-        errorMessage.includes('token') ||
-        errorMessage.includes('length') ||
-        errorMessage.includes('too long');
-
-      if (isContextError) {
-        logger.debug(`Context limit ${contextLimit} exceeded for model ${this.model}`);
-        return false;
-      }
-
-      // Other errors might not be context-related, so we can't conclude
-      throw error;
-    }
-  }
-
-  /**
-   * Get context limit for a specific model, including variant handling.
-   * 
-   * @param modelName The model name to check
-   * @returns Token limit for the model
-   */
-  private getModelContextLimit(modelName: string): number {
-    const DEFAULT_LIMIT = 4096;
-    const modelLower = modelName.toLowerCase();
-
-    // Exact model name matches
-    const EXACT_LIMITS: Record<string, number> = {
-      // OpenAI GPT models
-      'gpt-3.5-turbo': 4096,
-      'gpt-3.5-turbo-16k': 16384,
-      'gpt-3.5-turbo-0301': 4096,
-      'gpt-3.5-turbo-0613': 4096,
-      'gpt-3.5-turbo-1106': 16384,
-      'gpt-3.5-turbo-0125': 16384,
-      'gpt-4': 8192,
-      'gpt-4-0314': 8192,
-      'gpt-4-0613': 8192,
-      'gpt-4-32k': 32768,
-      'gpt-4-32k-0314': 32768,
-      'gpt-4-32k-0613': 32768,
-      'gpt-4-turbo': 128000,
-      'gpt-4-turbo-preview': 128000,
-      'gpt-4-1106-preview': 128000,
-      'gpt-4-0125-preview': 128000,
-      'gpt-4o': 128000,
-      'gpt-4o-2024-05-13': 128000,
-      'gpt-4o-2024-08-06': 128000,
-      'gpt-4o-mini': 128000,
-      'gpt-4o-mini-2024-07-18': 128000,
-
-      // DeepSeek models
-      'deepseek-coder': 16384,
-      'deepseek-chat': 32768,
-      'deepseek-v2': 128000,
-      'deepseek-v2.5': 128000,
-      'deepseek-v3': 128000,
-      'deepseek-v3.1': 128000,
-      'deepseekv3': 128000,
-      'deepseekv31': 128000,
-      'deepseek-coder-v2': 128000,
-      'deepseek/deepseek-chat-v3.1:free': 163800,
-
-      // Grok models
-      'x-ai/grok-4-fast:free': 2000000,
-
-      // Qwen models
-      'qwen-turbo': 8192,
-      'qwen-plus': 32768,
-      'qwen-max': 32768,
-      'qwen2': 32768,
-      'qwen2.5': 32768,
-      'qwen3': 128000,
-      'qwen3-coder': 128000,
-      'qwen-coder-plus': 128000,
-      'qwen-coder-turbo': 128000,
-
-      // Kimi (Moonshot) models
-      'moonshot-v1-8k': 8192,
-      'moonshot-v1-32k': 32768,
-      'moonshot-v1-128k': 128000,
-      'kimi-chat': 128000,
-
-      // Claude models
-      'claude-3-haiku': 200000,
-      'claude-3-sonnet': 200000,
-      'claude-3-opus': 200000,
-      'claude-3-5-sonnet': 200000,
-      'claude-3-5-haiku': 200000,
-
-      // Gemini models
-      'gemini-pro': 32768,
-      'gemini-1.5-pro': 1048576, // 1M tokens
-      'gemini-1.5-flash': 1048576,
-      'gemini-ultra': 32768,
-
-      // Yi models
-      'yi-34b-chat': 4096,
-      'yi-6b-chat': 4096,
-      'yi-large': 32768,
-      'yi-medium': 16384,
-
-      // Baichuan models
-      'baichuan2-turbo': 32768,
-      'baichuan2-turbo-192k': 192000,
-
-      // ChatGLM models
-      'glm-4': 128000,
-      'glm-4v': 128000,
-      'glm-3-turbo': 128000,
-      'chatglm3-6b': 8192,
-
-      // Ollama common models (estimated based on model architecture)
-      'llama2': 4096,
-      'llama2:70b': 4096,
-      'llama3': 8192,
-      'llama3:70b': 8192,
-      'llama3.1': 128000,
-      'llama3.1:70b': 128000,
-      'llama3.1:405b': 128000,
-      'codellama': 16384,
-      'codellama:34b': 16384,
-      'mistral': 32768,
-      'mixtral': 32768,
-      'phi3': 128000,
-      'gemma': 8192,
-      'gemma2': 8192,
-      'qwen2.5:72b': 32768,
-    };
-
-    // Check for exact match first
-    if (EXACT_LIMITS[modelLower]) {
-      return EXACT_LIMITS[modelLower];
-    }
-
-    // Pattern-based matching for variants and custom deployments
-    const MODEL_PATTERNS: Array<{ pattern: RegExp, limit: number, description: string }> = [
-      // DeepSeek variants (support model names with provider prefix)
-      { pattern: /(^|\/|:)(x)?deepseek[-_]?v?3\.?1/i, limit: 32000, description: 'DeepSeek V3.1 variants' },
-      { pattern: /(^|\/|:)(x)?deepseek[-_]?v?3/i, limit: 32000, description: 'DeepSeek V3 variants' },
-      { pattern: /(^|\/|:)(x)?deepseek[-_]?v?2\.?5?/i, limit: 8000, description: 'DeepSeek V2/V2.5 variants' },
-      { pattern: /(^|\/|:)(x)?deepseek[-_]?coder/i, limit: 32000, description: 'DeepSeek Coder variants' },
-      { pattern: /(^|\/|:)(x)?deepseek/i, limit: 8000, description: 'Other DeepSeek variants' },
-
-      // Qwen variants (support model names with provider prefix like "qwen/")
-      { pattern: /(^|\/|:)qwen[-_]?3[-_]?coder/i, limit: 128000, description: 'Qwen3 Coder variants' },
-      { pattern: /(^|\/|:)qwen[-_]?3/i, limit: 128000, description: 'Qwen3 variants' },
-      { pattern: /(^|\/|:)qwen[-_]?2\.?5/i, limit: 32768, description: 'Qwen2.5 variants' },
-      { pattern: /(^|\/|:)qwen[-_]?2/i, limit: 32768, description: 'Qwen2 variants' },
-      { pattern: /(^|\/|:)qwen[-_]?(coder|plus)/i, limit: 128000, description: 'Qwen Coder/Plus variants' },
-      { pattern: /(^|\/|:)qwen[-_]?max/i, limit: 32768, description: 'Qwen Max variants' },
-      { pattern: /(^|\/|:)qwen/i, limit: 8192, description: 'Other Qwen variants' },
-
-      // GPT variants and custom deployments (support model names with provider prefix)
-      { pattern: /(^|\/|:)gpt[-_]?4o[-_]?mini/i, limit: 128000, description: 'GPT-4o mini variants' },
-      { pattern: /(^|\/|:)gpt[-_]?4o/i, limit: 128000, description: 'GPT-4o variants' },
-      { pattern: /(^|\/|:)gpt[-_]?4[-_]?turbo/i, limit: 128000, description: 'GPT-4 turbo variants' },
-      { pattern: /(^|\/|:)gpt[-_]?4[-_]?32k/i, limit: 32768, description: 'GPT-4 32K variants' },
-      { pattern: /(^|\/|:)gpt[-_]?4/i, limit: 8192, description: 'GPT-4 variants' },
-      { pattern: /(^|\/|:)gpt[-_]?3\.?5[-_]?turbo[-_]?16k/i, limit: 16384, description: 'GPT-3.5 turbo 16K variants' },
-      { pattern: /(^|\/|:)gpt[-_]?3\.?5/i, limit: 4096, description: 'GPT-3.5 variants' },
-
-      // Claude variants (support model names with provider prefix)
-      { pattern: /(^|\/|:)claude[-_]?3[-_]?5/i, limit: 200000, description: 'Claude 3.5 variants' },
-      { pattern: /(^|\/|:)claude[-_]?3/i, limit: 200000, description: 'Claude 3 variants' },
-
-      // Gemini variants (support model names with provider prefix)
-      { pattern: /(^|\/|:)gemini[-_]?1\.?5/i, limit: 1048576, description: 'Gemini 1.5 variants' },
-      { pattern: /(^|\/|:)gemini/i, limit: 32768, description: 'Other Gemini variants' },
-
-      // Kimi/Moonshot variants (support model names with provider prefix)
-      { pattern: /(^|\/|:)(kimi|moonshot)[-_]?.*128k/i, limit: 128000, description: 'Kimi/Moonshot 128K variants' },
-      { pattern: /(^|\/|:)(kimi|moonshot)[-_]?.*32k/i, limit: 32768, description: 'Kimi/Moonshot 32K variants' },
-      { pattern: /(^|\/|:)(kimi|moonshot)/i, limit: 128000, description: 'Other Kimi/Moonshot variants' },
-
-      // LLaMA variants (support model names with provider prefix)
-      { pattern: /(^|\/|:)llama[-_]?3\.?1/i, limit: 128000, description: 'LLaMA 3.1 variants' },
-      { pattern: /(^|\/|:)llama[-_]?3/i, limit: 8192, description: 'LLaMA 3 variants' },
-      { pattern: /(^|\/|:)llama[-_]?2/i, limit: 4096, description: 'LLaMA 2 variants' },
-      { pattern: /(^|\/|:)codellama/i, limit: 16384, description: 'CodeLlama variants' },
-
-      // Other model families (support model names with provider prefix)
-      { pattern: /(^|\/|:)mixtral/i, limit: 32768, description: 'Mixtral variants' },
-      { pattern: /(^|\/|:)mistral/i, limit: 32768, description: 'Mistral variants' },
-      { pattern: /(^|\/|:)phi[-_]?3/i, limit: 128000, description: 'Phi-3 variants' },
-      { pattern: /(^|\/|:)yi[-_]?large/i, limit: 32768, description: 'Yi Large variants' },
-      { pattern: /(^|\/|:)yi/i, limit: 4096, description: 'Other Yi variants' },
-      { pattern: /(^|\/|:)glm[-_]?4/i, limit: 128000, description: 'GLM-4 variants' },
-      { pattern: /(^|\/|:)chatglm/i, limit: 8192, description: 'ChatGLM variants' },
-
-      // Grok variants (support model names with provider prefix)
-      { pattern: /(^|\/|:)x[-_]?ai[-_]?grok[-_]?4[-_]?fast/i, limit: 2000000, description: 'Grok 4 Fast variants' },
-      { pattern: /(^|\/|:)x[-_]?ai/i, limit: 2000000, description: 'Other Grok variants' },
-    ];
-
-    // Try pattern matching
-    for (const { pattern, limit, description } of MODEL_PATTERNS) {
-      if (pattern.test(modelName)) {
-        logger.debug(`Matched ${modelName} with pattern for ${description}, limit: ${limit}`);
-        return limit;
-      }
-    }
-
-    // Default fallback
-    logger.debug(`No specific limit found for model ${modelName}, using default ${DEFAULT_LIMIT}`);
-    return DEFAULT_LIMIT;
-  }
 
   /**
    * Estimate token count for text using an improved approach that handles different character types.
@@ -923,33 +632,38 @@ ${batchSummaries}`,
   /**
    * Calculate reserved tokens based on model context limit.
    * Reserves space for system prompt, response, and safety buffer.
-   * 
+   *
    * @param contextLimit Total context limit for the model
    * @returns Number of tokens to reserve
    */
   private calculateReservedTokens(contextLimit: number): number {
-    // Base system prompt tokens (estimated)
-    const SYSTEM_PROMPT_TOKENS = 800;
+    // System prompt tokens (increased for more complex prompts)
+    const SYSTEM_PROMPT_TOKENS = 1200;
 
-    // Expected response tokens (commit + branch + description)
-    const RESPONSE_TOKENS = 1000;
+    // Expected response tokens (commit + branch + description + title)
+    const RESPONSE_TOKENS = 1500;
 
     // Safety buffer percentage based on context size
     let bufferPercentage: number;
     if (contextLimit >= 128000) {
       bufferPercentage = 0.05; // 5% for large context models
     } else if (contextLimit >= 32000) {
-      bufferPercentage = 0.10; // 10% for medium context models
+      bufferPercentage = 0.08; // 8% for medium context models
     } else if (contextLimit >= 8000) {
-      bufferPercentage = 0.15; // 15% for smaller context models
+      bufferPercentage = 0.12; // 12% for smaller context models
     } else {
-      bufferPercentage = 0.20; // 20% for very small context models
+      bufferPercentage = 0.15; // 15% for very small context models
     }
 
     const bufferTokens = Math.ceil(contextLimit * bufferPercentage);
     const totalReserved = SYSTEM_PROMPT_TOKENS + RESPONSE_TOKENS + bufferTokens;
 
-    logger.debug(`Reserved tokens calculation: system=${SYSTEM_PROMPT_TOKENS}, response=${RESPONSE_TOKENS}, buffer=${bufferTokens} (${(bufferPercentage * 100).toFixed(1)}%), total=${totalReserved}`);
+    logger.debug(
+      `Reserved tokens: system=${SYSTEM_PROMPT_TOKENS}, ` +
+      `response=${RESPONSE_TOKENS}, ` +
+      `buffer=${bufferTokens} (${(bufferPercentage * 100).toFixed(1)}%), ` +
+      `total=${totalReserved} / ${contextLimit} (${((totalReserved / contextLimit) * 100).toFixed(1)}%)`
+    );
 
     return totalReserved;
   }

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -9,20 +9,20 @@ import { parse } from 'shell-quote';
  * - macOS/Linux: bash or zsh
  */
 export class Shell {
-  private static readonly instances = new Map<string, Shell>();
+  private static _instance: Shell | null = null;
 
   private constructor() {
     logger.debug(`Initializing Shell, platform: ${platform()} process.cwd: ${process.cwd()}`);
   }
 
   static instance(): Shell {
-    const pwd = process.cwd();
-    if (Shell.instances.get(pwd)) {
-      return Shell.instances.get(pwd)!;
+    // Shell should be a true singleton, not cached per directory
+    // Git commands will automatically find the .git directory by traversing up
+    if (Shell._instance) {
+      return Shell._instance;
     }
-    const shell = new Shell();
-    Shell.instances.set(pwd, shell);
-    return shell;
+    Shell._instance = new Shell();
+    return Shell._instance;
   }
   /**
    * Execute a shell command and return stdout as string
@@ -50,6 +50,7 @@ export class Shell {
       }
 
       // Always use shell: false to avoid command injection
+      // Git commands work correctly from subdirectories as git traverses up to find .git
       const result: SpawnSyncReturns<string> = spawnSync(
         command,
         commandArgs,


### PR DESCRIPTION
## 变更内容

### 新增功能
- 添加了 OpenAI 模型最大上下文 token 数的可配置选项 `max_context_tokens`
- 支持通过环境变量 `OPENAI_MAX_CONTEXT_TOKENS` 配置
- 新增 CLI 参数 `--openai-max-context-tokens`（短参数 `-omct`）
- 在配置示例文件中添加了详细的模型推荐值说明

### 核心改进
- 移除了自动模型上下文检测逻辑，改为用户手动配置
- 默认上下文 token 数设为 8192
- 更新了配置接口、加载器和解析逻辑
- 优化了 OpenAI 服务的初始化参数

### 文档更新
- 在 `config.example.yaml` 中添加了详细的模型上下文长度推荐值
- 包含常见模型如 gpt-3.5-turbo、gpt-4、gpt-4-turbo、claude-3.5-sonnet 等的推荐配置

## 变更原因

1. **提高准确性**：自动模型检测可能不准确，特别是对于自定义部署或新模型
2. **用户控制**：让用户根据具体使用的模型文档配置正确的上下文限制
3. **避免错误**：防止因上下文限制设置不当导致的 API 调用失败
4. **性能优化**：用户可以针对大模型（如 128K token 的模型）配置更高的限制

## 测试方法

1. **配置测试**：
   - 在配置文件中设置 `openai.max_context_tokens: 16384`
   - 使用环境变量 `OPENAI_MAX_CONTEXT_TOKENS=16384`
   - 使用 CLI 参数 `--openai-max-context-tokens 16384`

2. **功能验证**：
   - 运行 `aiflow` 命令验证配置是否正确加载
   - 检查日志输出中的 `maxContextTokens` 值
   - 测试不同模型配置下的提交信息生成功能

3. **边界测试**：
   - 测试无效数值（如非数字字符串）的处理
   - 验证默认值（8192）在未配置时的使用
   - 测试各种模型配置下的 token 计算准确性